### PR TITLE
Check if setting exists before assigning it to settings class

### DIFF
--- a/src/libs/settings.ts
+++ b/src/libs/settings.ts
@@ -17,7 +17,7 @@ export default class SettingsManager {
     const json: any = {};
 
     // Read all entries in correct settings object and make a json object to write
-    Object.entries(SettingsManager.getObjectFromName(which)).forEach((pair) => {
+    Object.entries(this.getObjectFromName(which)).forEach((pair) => {
       // Remove '_' from pair[0]/key then set it to pair[1]/value
       json[pair[0].substring(1)] = pair[1];
     });
@@ -40,7 +40,19 @@ export default class SettingsManager {
 
         // If file isn't empty, cast json from setting file to correct object
         if (data != "") {
-          Object.assign(SettingsManager.getObjectFromName(which), JSON.parse(data));
+          const dataJson = JSON.parse(data);
+          const settingsKeys = Object.keys(this.getObjectFromName(which));
+
+          // Delete items in `dataJson` that aren't present
+          // in the current settings class being processed
+          Object.keys(dataJson).forEach((k) => {
+            if (!settingsKeys.includes(`_${k}`)) {
+              delete dataJson[k];
+            }
+          });
+
+          // Assign dataJson to settings class
+          Object.assign(this.getObjectFromName(which), dataJson);
         }
 
         // Write settings back to file, incase of missing rules


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Previously, it didn't check if there were non-existent settings in the settings file it was reading. It would just blindly assign it to the settings object.

Now, it deletes all non-existent settings before assigning them all to the settings object.
