### PR TITLE
Fix desktop notification on Windows

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -108,7 +108,6 @@ function registerChannels(win: BrowserWindow) {
       await notifWin.loadURL(`${process.env.WEBPACK_DEV_SERVER_URL}#/${page}`);
     } else {
       // Load the index.html when not in development
-      // notifWin.loadURL(`file://${path.join(__dirname, `index.html/#/${page}`)}`);
       notifWin.loadURL(`file://${__dirname}/index.html#${page}`);
     }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -102,12 +102,14 @@ function registerChannels(win: BrowserWindow) {
 
     // Load desktopNotification view
     const page = `desktopNotification/${args.desc}/${args.icon}`;
+
     if (process.env.WEBPACK_DEV_SERVER_URL) {
       // Use dev server in development
       await notifWin.loadURL(`${process.env.WEBPACK_DEV_SERVER_URL}#/${page}`);
     } else {
       // Load the index.html when not in development
-      notifWin.loadURL(`file://${path.join(__dirname, `index.html/#/${page}`)}`);
+      // notifWin.loadURL(`file://${path.join(__dirname, `index.html/#/${page}`)}`);
+      notifWin.loadURL(`file://${__dirname}/index.html#${page}`);
     }
 
     // Close window after defined duration


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Desktop notification on Windows was showing the Recordings page, instead of the DesktopNotification page.

Closes #162 