### PR TITLE
Fix refresh on videoPlayer view removing videoPath param

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -19,6 +19,7 @@ import Dragger from "./../components/Dragger.vue";
 import Nav from "./../components/Nav.vue";
 import router from "./../router";
 import { AppSettings, GeneralSettings } from "./../libs/settings";
+import "@/libs/helpers/extensions";
 
 @Component({
   components: {
@@ -28,13 +29,18 @@ import { AppSettings, GeneralSettings } from "./../libs/settings";
 })
 export default class DefaultLayout extends Vue {
   mounted() {
-    // Redirect to startup page defined in settings
-    // If startupPage setting is a page in the application, redirect to it
-    // Else go to first page in AppSettings.pages setting
-    if (AppSettings.pages.includes(GeneralSettings.startupPage)) {
-      router.push(GeneralSettings.startupPage).catch(() => {});
-    } else {
-      router.push(AppSettings.pages[0]).catch(() => {});
+    const excludedPages = ["videoPlayer"];
+
+    // If user is on an excludedPage, don't push user to their default startupPage.
+    if (!this.$route.name.equalsAnyOf(excludedPages)) {
+      // Redirect to startup page defined in settings
+      // If startupPage setting is a page in the application, redirect to it
+      // Else go to first page in AppSettings.pages setting
+      if (AppSettings.pages.includes(GeneralSettings.startupPage)) {
+        router.push(GeneralSettings.startupPage).catch(() => {});
+      } else {
+        router.push(AppSettings.pages[0]).catch(() => {});
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Stopped code in DefaultLayout from pushing user to their default `startupPage` if they are on an exludedPage (videoPlayer view).

Closes #169 