### PR TITLE
Add default tooltip styling

### DIFF
--- a/src/styles/_norm.scss
+++ b/src/styles/_norm.scss
@@ -60,6 +60,12 @@ a {
       cursor: grabbing;
     }
   }
+
+  .noUi-tooltip {
+    color: $textPrimary;
+    background-color: $darkAccentColor;
+    box-shadow: 0px 0px 8px $darkAccentColor;
+  }
 }
 
 // Default slider styling


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Add default tooltip styling

Closes #173 
