### PR TITLE
Fix progress bar scrubber jitter

### DIFF
--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -16,6 +16,7 @@
         ref="sliderBar"
         class="sliderBar"
         type="range"
+        :value="sliderValue"
         :min="sliderMin"
         :max="sliderMax"
         :step="sliderStep"

--- a/src/styles/_norm.scss
+++ b/src/styles/_norm.scss
@@ -34,11 +34,12 @@ a {
 
 // Default nouislider styling
 .noUi-target {
+  border: unset;
+
   &,
   * {
     box-shadow: unset;
     outline: unset;
-    border: unset;
   }
 
   .noUi-handle {

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -174,12 +174,8 @@ export default class VideoPlayer extends Vue {
     // Update volume once now, so default volume value is applied
     this.updateVolume(this.volume);
 
-    this.video.addEventListener("play", () => {
-      this.playPause(false);
-    });
-    this.video.addEventListener("pause", () => {
-      this.playPause(false);
-    });
+    this.video.addEventListener("play", () => this.playPause(false));
+    this.video.addEventListener("pause", () => this.playPause(false));
     this.video.addEventListener("timeupdate", this.updateProgressBarTime);
 
     noUiSlider.create(this.progressBar, {

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -171,6 +171,9 @@ export default class VideoPlayer extends Vue {
 
     this.maxVideoTime = this.video.duration;
 
+    // Update volume once now, so default volume value is applied
+    this.updateVolume(this.volume);
+
     this.video.addEventListener("play", () => {
       this.playPause(false);
     });

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -183,7 +183,7 @@ export default class VideoPlayer extends Vue {
       behaviour: "snap",
       range: {
         min: 0,
-        max: this.video.duration // + 99999
+        max: this.video.duration
       },
       pips: {
         mode: PipsMode.Count,
@@ -223,21 +223,21 @@ export default class VideoPlayer extends Vue {
   }
 
   /**
-   * Update time on progress bar
+   * Update time on progress bar with current time on video.
    */
   updateProgressBarTime() {
     this.progressBar.noUiSlider!.set(this.video.currentTime);
   }
 
   /**
-   * Re-add all events to Progress bar
+   * Re-add all events to progress bar.
    */
   addProgressBarEvents() {
     // First remove all events
     this.progressBar.noUiSlider!.off("");
 
-    this.progressBar.noUiSlider!.on("slide", (values: any[]) => {
-      this.updateVideoTime(values[0]);
+    this.progressBar.noUiSlider!.on("slide", (_0: any, _1: any, unencoded: number[]) => {
+      this.updateVideoTime(unencoded[0]);
     });
 
     this.progressBar.noUiSlider!.on("start", () => {
@@ -536,11 +536,7 @@ export default class VideoPlayer extends Vue {
       background-color: $secondaryColor;
 
       .noUi-origin {
-        transition: transform 80ms ease-in;
-
-        &:active {
-          transition: transform 0ms;
-        }
+        transition: none;
       }
 
       .noUi-handle {

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -181,6 +181,7 @@ export default class VideoPlayer extends Vue {
     noUiSlider.create(this.progressBar, {
       start: [0],
       behaviour: "snap",
+      animate: false,
       range: {
         min: 0,
         max: this.video.duration
@@ -535,10 +536,6 @@ export default class VideoPlayer extends Vue {
       height: 100%;
       background-color: $secondaryColor;
 
-      .noUi-origin {
-        transition: none;
-      }
-
       .noUi-handle {
         top: 0;
         height: 40px;
@@ -605,6 +602,7 @@ export default class VideoPlayer extends Vue {
 
       .noUi-tooltip {
         display: none;
+        bottom: 165%;
       }
     }
   }


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Disabled transition on progressbar to remove scubber jitter bug. Better this way anyways, it avoids not being able to click to skip to another part of the video for a second after skipping.

Only drawback is videos that are short, the scrubber will snap whilst playing said video. That said it's minor, most won't notice and most videos are going to be long enough to where this isn't the case.

Closes #178 