### PR TITLE
Zoomable timeline

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -90,6 +90,11 @@ export default class Icon extends Vue {
         return `
           <path d="M68 38.857H38.857V68h-9.714V38.857H0v-9.714h29.143V0h9.714v29.143H68v9.714z" />
         `;
+      case "min2":
+        this.viewBox = "0 0 12 12";
+        return `
+          <rect width="10" height="2" x="1" y="5"></rect>
+        `;
       case "min":
         this.viewBox = "0 0 12 12";
         return `

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -362,14 +362,13 @@ export default class VideoPlayer extends Vue {
       this.updateTotalLengthOfClips(values);
     });
 
-    const slideHandler = (values: any, handle: any) => {
+    this.clipsBar.noUiSlider!.on("slide", (values: any, handle: any) => {
       // Only do anything if user isn't dragging so we can avoid
       // running actions twice, since slide is also ran when dragging.
       if (!isDragging) {
         this.updateVideoTime(values[handle]);
       }
-    };
-    this.clipsBar.noUiSlider!.on("slide", slideHandler);
+    });
 
     this.clipsBar.noUiSlider!.on("drag", (values: any, handle: any) => {
       isDragging = true;
@@ -378,7 +377,11 @@ export default class VideoPlayer extends Vue {
     });
 
     // Show tooltip on drag
-    this.clipsBar.noUiSlider!.on("start", (_: any, handle: any) => {
+    this.clipsBar.noUiSlider!.on("start", (values: any, handle: any) => {
+      // Also update tooltip on start, to avoid users seeing
+      // it jump around if they dont drag right away (or never drag)
+      this.updateTooltip(values, handle);
+
       this.getPairFromHandle(handle).tooltip.style.display = "block";
     });
 
@@ -591,6 +594,18 @@ export default class VideoPlayer extends Vue {
 
       &::-webkit-scrollbar-track {
         background-color: $primaryColor;
+      }
+
+      .clipsBar {
+        .noUi-tooltip {
+          bottom: -5%;
+          height: 25px;
+          background-color: $lightHoverColor;
+          border: unset;
+          box-shadow: unset;
+          font-weight: bold;
+          text-shadow: 1px 1px black;
+        }
       }
     }
   }

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -216,7 +216,20 @@ export default class VideoPlayer extends Vue {
   addTimelineBarEvents() {
     // Scroll across by using mouse wheel
     this.timelineBar.addEventListener("wheel", (e) => {
-      if (e.deltaY < 0) {
+      let wheelUp = e.deltaY < 0;
+
+      // If holding control, adjust zoom instead of scrolling
+      if (e.ctrlKey) {
+        if (wheelUp) {
+          this.adjustZoom(true);
+        } else {
+          this.adjustZoom(false);
+        }
+
+        return;
+      }
+
+      if (wheelUp) {
         this.timelineBar.scrollBy(-50, 0);
       } else {
         this.timelineBar.scrollBy(50, 0);
@@ -564,7 +577,7 @@ export default class VideoPlayer extends Vue {
 
   &.timelineZoomed {
     video {
-      height: calc(100% - 98px); // Make height of video all take up all blank space on page
+      height: calc(100% - 95px); // Make height of video all take up all blank space on page
     }
 
     .timeline {

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -35,6 +35,9 @@
 
       <Button text="ADD CLIP" @click="addClip" />
 
+      <Button icon="add" @click="adjustZoom(true)" />
+      <Button icon="min2" @click="adjustZoom(false)" />
+
       <Button
         class="rightFromHere"
         icon="arrow"
@@ -91,6 +94,7 @@ export default class VideoPlayer extends Vue {
   volumeIcon = "volumeMax";
   volume = 0.8;
   showTimeAsElapsed = false;
+  timelineZoom = 100;
 
   get currentVideoTime() {
     if (this.video != undefined) {
@@ -228,6 +232,17 @@ export default class VideoPlayer extends Vue {
    */
   updateProgressBarTime() {
     this.progressBar.noUiSlider!.set(this.video.currentTime);
+  }
+
+  adjustZoom(increase: boolean) {
+    const min = 100;
+    const max = 1000;
+
+    if (increase && this.timelineZoom != max) {
+      this.timelineZoom += 50;
+    } else if (!increase && this.timelineZoom != min) {
+      this.timelineZoom -= 50;
+    }
   }
 
   /**

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="videoExists" class="videoPlayerContainer">
+  <div v-if="videoExists" ref="videoEditor" class="videoEditor">
     <video
       ref="videoPlayer"
       id="video"
@@ -8,7 +8,7 @@
       @click="playPause"
     ></video>
 
-    <div ref="timeline" class="timeline">
+    <div class="timeline">
       <div ref="progressBar" class="progressBar"></div>
       <div ref="clipsBar" class="clipsBar"></div>
     </div>
@@ -83,7 +83,7 @@ export default class VideoPlayer extends Vue {
   @Prop({ required: true }) videoPath: string;
 
   private video: HTMLVideoElement;
-  private timelineBar: target;
+  private videoEditor: target;
   private progressBar: target;
   private clipsBar: target;
 
@@ -171,7 +171,7 @@ export default class VideoPlayer extends Vue {
    */
   videoLoaded() {
     this.video = this.$refs.videoPlayer as HTMLVideoElement;
-    this.timelineBar = this.$refs.timeline as target;
+    this.videoEditor = this.$refs.videoEditor as target;
     this.progressBar = this.$refs.progressBar as target;
     this.clipsBar = this.$refs.clipsBar as target;
 
@@ -251,14 +251,15 @@ export default class VideoPlayer extends Vue {
       this.timelineZoom -= 50;
     }
 
-    // Adjust width of progressBar
+    // Adjust width of bars
     this.progressBar.style.width = `${this.timelineZoom}%`;
+    this.clipsBar.style.width = `${this.timelineZoom}%`;
 
     // Add/remove `zoomed` class on progressBar
     if (this.timelineZoom !== min) {
-      this.timelineBar.classList.add("zoomed");
+      this.videoEditor.classList.add("timelineZoomed");
     } else {
-      this.timelineBar.classList.remove("zoomed");
+      this.videoEditor.classList.remove("timelineZoomed");
     }
   }
 
@@ -523,7 +524,7 @@ export default class VideoPlayer extends Vue {
 </script>
 
 <style lang="scss">
-.videoPlayerContainer {
+.videoEditor {
   width: 100%;
   height: 100%;
   overflow-x: hidden;
@@ -547,14 +548,13 @@ export default class VideoPlayer extends Vue {
     }
   }
 
-  .timeline {
-    width: 100%;
-    height: 40px;
-    padding: 0 10px;
-    background-color: $secondaryColor;
+  &.timelineZoomed {
+    video {
+      height: calc(100% - 98px); // Make height of video all take up all blank space on page
+    }
 
-    &.zoomed {
-      padding-bottom: 48px;
+    .timeline {
+      height: 45px;
       overflow-y: hidden;
       overflow-x: auto;
 
@@ -563,17 +563,18 @@ export default class VideoPlayer extends Vue {
       }
 
       &::-webkit-scrollbar-track {
-        padding-top: 50px;
         background-color: $primaryColor;
       }
-
-      .progressBar .noUi-pips {
-        top: 13px;
-      }
     }
+  }
+
+  .timeline {
+    width: 100%;
+    height: 40px;
+    padding: 0 10px;
+    background-color: $secondaryColor;
 
     .progressBar {
-      // width: 200%;
       height: 100%;
       background-color: $secondaryColor;
 
@@ -613,7 +614,6 @@ export default class VideoPlayer extends Vue {
     .clipsBar {
       position: relative;
       top: -100%;
-      width: 100%;
       height: 100%;
       background-color: transparent;
 

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -695,6 +695,7 @@ export default class VideoPlayer extends Vue {
       .noUi-tooltip {
         display: none;
         bottom: 165%;
+        pointer-events: none;
       }
     }
   }

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -8,7 +8,7 @@
       @click="playPause"
     ></video>
 
-    <div class="timeline">
+    <div ref="timeline" class="timeline">
       <div ref="progressBar" class="progressBar"></div>
       <div ref="clipsBar" class="clipsBar"></div>
     </div>
@@ -84,6 +84,7 @@ export default class VideoPlayer extends Vue {
 
   private video: HTMLVideoElement;
   private videoEditor: target;
+  private timelineBar: target;
   private progressBar: target;
   private clipsBar: target;
 
@@ -172,6 +173,7 @@ export default class VideoPlayer extends Vue {
   videoLoaded() {
     this.video = this.$refs.videoPlayer as HTMLVideoElement;
     this.videoEditor = this.$refs.videoEditor as target;
+    this.timelineBar = this.$refs.timeline as target;
     this.progressBar = this.$refs.progressBar as target;
     this.clipsBar = this.$refs.clipsBar as target;
 
@@ -207,7 +209,19 @@ export default class VideoPlayer extends Vue {
       }
     });
 
+    this.addTimelineBarEvents();
     this.addProgressBarEvents();
+  }
+
+  addTimelineBarEvents() {
+    // Scroll across by using mouse wheel
+    this.timelineBar.addEventListener("wheel", (e) => {
+      if (e.deltaY < 0) {
+        this.timelineBar.scrollBy(-50, 0);
+      } else {
+        this.timelineBar.scrollBy(50, 0);
+      }
+    });
   }
 
   /**

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -8,7 +8,7 @@
       @click="playPause"
     ></video>
 
-    <div class="progressBarContainer">
+    <div ref="timeline" class="timeline">
       <div ref="progressBar" class="progressBar"></div>
       <div ref="clipsBar" class="clipsBar"></div>
     </div>
@@ -83,6 +83,7 @@ export default class VideoPlayer extends Vue {
   @Prop({ required: true }) videoPath: string;
 
   private video: HTMLVideoElement;
+  private timelineBar: target;
   private progressBar: target;
   private clipsBar: target;
 
@@ -170,6 +171,7 @@ export default class VideoPlayer extends Vue {
    */
   videoLoaded() {
     this.video = this.$refs.videoPlayer as HTMLVideoElement;
+    this.timelineBar = this.$refs.timeline as target;
     this.progressBar = this.$refs.progressBar as target;
     this.clipsBar = this.$refs.clipsBar as target;
 
@@ -234,14 +236,29 @@ export default class VideoPlayer extends Vue {
     this.progressBar.noUiSlider!.set(this.video.currentTime);
   }
 
+  /**
+   * Adjust zoom up or down.
+   * @param increase If should increase or decrease zoom.
+   */
   adjustZoom(increase: boolean) {
     const min = 100;
     const max = 1000;
 
+    // Increase/decrease `timelineZoom`
     if (increase && this.timelineZoom != max) {
       this.timelineZoom += 50;
     } else if (!increase && this.timelineZoom != min) {
       this.timelineZoom -= 50;
+    }
+
+    // Adjust width of progressBar
+    this.progressBar.style.width = `${this.timelineZoom}%`;
+
+    // Add/remove `zoomed` class on progressBar
+    if (this.timelineZoom !== min) {
+      this.timelineBar.classList.add("zoomed");
+    } else {
+      this.timelineBar.classList.remove("zoomed");
     }
   }
 
@@ -530,21 +547,30 @@ export default class VideoPlayer extends Vue {
     }
   }
 
-  .progressBarContainer {
+  .timeline {
     width: 100%;
     height: 40px;
     padding: 0 10px;
     background-color: $secondaryColor;
-    // overflow-y: hidden;
-    // overflow-x: auto;
 
-    // &::-webkit-scrollbar {
-    //   height: 5px;
-    // }
+    &.zoomed {
+      padding-bottom: 48px;
+      overflow-y: hidden;
+      overflow-x: auto;
 
-    // &::-webkit-scrollbar-track {
-    //   background-color: $secondaryColor;
-    // }
+      &::-webkit-scrollbar {
+        height: 5px;
+      }
+
+      &::-webkit-scrollbar-track {
+        padding-top: 50px;
+        background-color: $primaryColor;
+      }
+
+      .progressBar .noUi-pips {
+        top: 13px;
+      }
+    }
 
     .progressBar {
       // width: 200%;
@@ -571,6 +597,15 @@ export default class VideoPlayer extends Vue {
 
         .noUi-value {
           transform: translateX(-50%);
+
+          &:nth-child(2) {
+            transform: translateX(-10%);
+          }
+
+          &:last-child {
+            transform: translateX(-90%);
+            margin-right: 1px;
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Make timeline zoomable with new zoom controls, or by using `ctrl+mousewheel`. You can also use your mousewheel to scroll across the timeline whilst it is zoomed in.

Had to move clip tooltip (that shows the clips length) to inside the clip, whilst the timeline is zoomed in otherwise the clip would be cutoff by the overflow setting. For some reason you can't have one axis be shown and another be on scroll.

Closes #180 
