### PR TITLE
Create custom tooltips

### DIFF
--- a/src/components/ui/ButtonConnector.vue
+++ b/src/components/ui/ButtonConnector.vue
@@ -16,14 +16,15 @@ export default class ButtonConnector extends Vue {}
   display: flex;
   flex-flow: row;
   height: 100%;
-  border: 2px solid $secondaryColor;
-  border-radius: 3px;
 
   .btnWrapper {
+    $border: 2px solid $secondaryColor;
+
     margin-left: 0;
 
     &:first-child:not(:only-child) ::v-deep .mainBtn {
-      border-right: 2px solid $secondaryColor;
+      border-left: $border;
+      border-right: $border;
     }
 
     &:first-child ::v-deep .mainBtn {
@@ -31,18 +32,24 @@ export default class ButtonConnector extends Vue {}
       border-radius: 3px 0 0 3px;
     }
 
+    & * ::v-deep .mainBtn {
+      border-right: unset;
+    }
+
     &:last-child ::v-deep .mainBtn {
+      border-right: $border;
       border-radius: 0 3px 3px 0;
     }
 
-    ::v-deep #outlined {
+    &:not(:first-child) ::v-deep #outlined {
+      border-left: unset;
       padding: 5px;
-      border: unset;
     }
 
     ::v-deep .mainBtn {
-      border: unset;
-      border-left: 2px solid $secondaryColor;
+      border-top: $border;
+      border-bottom: $border;
+      border-left: unset;
       border-radius: unset;
     }
   }

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -63,12 +63,14 @@ export default class DefaultLayout extends Vue {
 
         tooltip.innerHTML = el.getAttribute("tooltip")!;
 
+        tooltip.style.transform = "scale(1)";
         tooltip.style.top = `${er.top - er.height - 3}px`;
         tooltip.style.left = `${er.left + er.width / 2 - tooltip.getBoundingClientRect().width / 2}px`;
         tooltip.style.opacity = "1";
       });
 
       el.addEventListener("mouseleave", () => {
+        tooltip.style.transform = "scale(0.85)";
         tooltip.style.opacity = "0";
       });
     }

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -1,9 +1,6 @@
 <template>
   <div>
-    <div id="tooltip">
-      <div class="arrow"></div>
-    </div>
-
+    <div id="tooltip"></div>
     <section id="notifications"></section>
 
     <section id="top">
@@ -50,6 +47,10 @@ export default class DefaultLayout extends Vue {
     this.applyTooltips();
   }
 
+  updated() {
+    this.applyTooltips();
+  }
+
   applyTooltips() {
     const tooltip = document.getElementById("tooltip")!;
     let els = document.querySelectorAll("[tooltip]");
@@ -57,22 +58,17 @@ export default class DefaultLayout extends Vue {
     for (let i = 0, n = els.length; i < n; ++i) {
       let el = els[i];
 
-      el.addEventListener("mouseover", () => {
-        const r = el.getBoundingClientRect();
-        // console.log(r);
+      el.addEventListener("mouseenter", () => {
+        const er = el.getBoundingClientRect();
 
         tooltip.innerHTML = el.getAttribute("tooltip")!;
 
-        tooltip.style.transform = "scale(1)";
-        tooltip.style.top = `${r.top - r.height - 3}px`;
-        console.log(tooltip.style.transform, `${r.left + r.width / 2 - tooltip.getBoundingClientRect().width / 2}px`);
-        tooltip.style.left = `${r.left + r.width / 2 - tooltip.getBoundingClientRect().width / 2}px`;
-
+        tooltip.style.top = `${er.top - er.height - 3}px`;
+        tooltip.style.left = `${er.left + er.width / 2 - tooltip.getBoundingClientRect().width / 2}px`;
         tooltip.style.opacity = "1";
       });
 
       el.addEventListener("mouseleave", () => {
-        tooltip.style.transform = "scale(0.85)";
         tooltip.style.opacity = "0";
       });
     }
@@ -100,7 +96,7 @@ section#main {
   border-radius: 3px;
   box-shadow: 0px 0px 8px $darkAccentColor;
   font-size: 13px;
-  transition: opacity 150ms ease-in-out, left 25ms ease-in-out, transform 50ms ease;
+  transition: opacity 150ms ease-in-out, left 25ms ease-in;
   z-index: 100;
   pointer-events: none;
 

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <div id="tooltip">
+      <div class="arrow"></div>
+    </div>
+
     <section id="notifications"></section>
 
     <section id="top">
@@ -13,7 +17,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { Vue, Component } from "vue-property-decorator";
 import Dragger from "./../components/Dragger.vue";
 import Nav from "./../components/Nav.vue";
@@ -42,6 +46,36 @@ export default class DefaultLayout extends Vue {
         router.push(AppSettings.pages[0]).catch(() => {});
       }
     }
+
+    this.applyTooltips();
+  }
+
+  applyTooltips() {
+    const tooltip = document.getElementById("tooltip")!;
+    let els = document.querySelectorAll("[tooltip]");
+
+    for (let i = 0, n = els.length; i < n; ++i) {
+      let el = els[i];
+
+      el.addEventListener("mouseover", () => {
+        const r = el.getBoundingClientRect();
+        // console.log(r);
+
+        tooltip.innerHTML = el.getAttribute("tooltip")!;
+
+        tooltip.style.transform = "scale(1)";
+        tooltip.style.top = `${r.top - r.height - 3}px`;
+        console.log(tooltip.style.transform, `${r.left + r.width / 2 - tooltip.getBoundingClientRect().width / 2}px`);
+        tooltip.style.left = `${r.left + r.width / 2 - tooltip.getBoundingClientRect().width / 2}px`;
+
+        tooltip.style.opacity = "1";
+      });
+
+      el.addEventListener("mouseleave", () => {
+        tooltip.style.transform = "scale(0.85)";
+        tooltip.style.opacity = "0";
+      });
+    }
   }
 }
 </script>
@@ -56,5 +90,30 @@ section#main {
   height: calc(100vh - 66px);
   overflow-y: auto;
   background-color: $primaryColor;
+}
+
+#tooltip {
+  position: fixed;
+  opacity: 0;
+  padding: 8px 10px;
+  background-color: $darkAccentColor;
+  border-radius: 3px;
+  box-shadow: 0px 0px 8px $darkAccentColor;
+  font-size: 13px;
+  transition: opacity 150ms ease-in-out, left 25ms ease-in-out, transform 50ms ease;
+  z-index: 100;
+  pointer-events: none;
+
+  &:before {
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: $darkAccentColor;
+  }
 }
 </style>

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -60,12 +60,22 @@ export default class DefaultLayout extends Vue {
 
       el.addEventListener("mouseenter", () => {
         const er = el.getBoundingClientRect();
+        const getTooltipLeftPos = () => {
+          let tw = tooltip.getBoundingClientRect().width;
+          let left = er.left + er.width / 2 - tw / 2;
+
+          if (left + tw > window.innerWidth) {
+            left = window.innerWidth - tw - 5;
+          }
+
+          return left;
+        };
 
         tooltip.innerHTML = el.getAttribute("tooltip")!;
 
         tooltip.style.transform = "scale(1)";
-        tooltip.style.top = `${er.top - er.height - 3}px`;
-        tooltip.style.left = `${er.left + er.width / 2 - tooltip.getBoundingClientRect().width / 2}px`;
+        tooltip.style.top = `${er.top - er.height - 2}px`;
+        tooltip.style.left = `${getTooltipLeftPos()}px`;
         tooltip.style.opacity = "1";
       });
 
@@ -98,20 +108,9 @@ section#main {
   border-radius: 3px;
   box-shadow: 0px 0px 8px $darkAccentColor;
   font-size: 13px;
+  white-space: nowrap;
   transition: opacity 150ms ease-in-out, left 25ms ease-in;
   z-index: 100;
   pointer-events: none;
-
-  &:before {
-    content: "";
-    position: absolute;
-    width: 0;
-    height: 0;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 6px solid transparent;
-    border-top-color: $darkAccentColor;
-  }
 }
 </style>

--- a/src/views/VideoPlayer.vue
+++ b/src/views/VideoPlayer.vue
@@ -35,13 +35,13 @@
 
       <Button text="Add Clip" @click="addClip" />
 
-      <Button icon="add" @click="adjustZoom(true)" />
-      <Button icon="min2" @click="adjustZoom(false)" />
+      <Button icon="add" @click="adjustZoom(true)" tooltip="Zoom In" />
+      <Button icon="min2" @click="adjustZoom(false)" tooltip="Zoom Out" />
 
       <div class="rightFromHere"></div>
 
       <ButtonConnector>
-        <Button :outlined="true" @click="playClips">
+        <Button :outlined="true" @click="playClips" tooltip="Play All Clips">
           <template slot="info">
             <div>
               <Icon i="clips" wh="18" />
@@ -55,7 +55,7 @@
           </template>
         </Button>
 
-        <Button icon="arrow" :disabled="continueBtnDisabled" @click="saveClips" />
+        <Button icon="arrow" :disabled="continueBtnDisabled" @click="saveClips" tooltip="Continue" />
       </ButtonConnector>
     </div>
   </div>


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Create custom tooltip that can easily be applied to elements by adding the `tooltip` attribute to them as such: `<button tooltip="click me to click something" />`.

Added tooltips to controls in VideoEditor that need more context.

Closes #188
