### PR TITLE
VideoEditor: Create back button and show video file names instead of full path for their names

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -1,5 +1,5 @@
 <template>
-  <svg v-html="Icon" :width="wh" :height="wh" :viewBox="viewBox"></svg>
+  <svg v-html="Icon" ref="icon" :width="wh" :height="wh" :viewBox="viewBox"></svg>
 </template>
 
 <script lang="ts">
@@ -9,6 +9,7 @@ import { Prop, Component, Vue } from "vue-property-decorator";
 export default class Icon extends Vue {
   @Prop({ required: true }) i: string;
   @Prop({ default: 24 }) wh: number;
+  @Prop({ required: false }) direction?: "up" | "down" | "left" | "right";
 
   viewBox = "0 0 24 24";
 
@@ -61,9 +62,9 @@ export default class Icon extends Vue {
       case "volumeMax":
         this.viewBox = "0 0 18 18";
         return `
-          <path fill-rule="evenodd" clip-rule="evenodd" 
-            d="M0 6v6h4l5 5V1L4 6H0zm7-.17v6.34L4.83 10H2V8h2.83L7 5.83zM13.5 9A4.5 4.5 0 0011 
-            4.97v8.05c1.48-.73 2.5-2.25 2.5-4.02zM11 .23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 
+          <path fill-rule="evenodd" clip-rule="evenodd"
+            d="M0 6v6h4l5 5V1L4 6H0zm7-.17v6.34L4.83 10H2V8h2.83L7 5.83zM13.5 9A4.5 4.5 0 0011
+            4.97v8.05c1.48-.73 2.5-2.25 2.5-4.02zM11 .23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5
             6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"
           />
         `;
@@ -113,15 +114,13 @@ export default class Icon extends Vue {
             1.576 11 1 10.424 5.417 6 1 1.576 1.576 1 6 5.417 10.424 1">
           </polygon>
         `;
-      // Arrow points right by default, plan is to just rotate it when needed instead of having arrows for each direction
       case "arrow":
         this.viewBox = "0 0 57 57";
         return `
-          <path fill-rule="evenodd" clip-rule="evenodd" 
+          <path fill-rule="evenodd" clip-rule="evenodd"
             d="M28.5.167L23.506 5.16 43.27 24.957H.167v7.084h43.102L23.506 51.84l4.994 4.993L56.833 28.5 28.5.167z"
           />
         `;
-      // Chevron points right by default, plan is to just rotate it when needed instead of having chevrons for each direction
       case "chevron":
         this.viewBox = "0 0 8 12";
         return `
@@ -130,23 +129,23 @@ export default class Icon extends Vue {
       case "clips":
         this.viewBox = "0 0 30 30";
         return `
-          <path 
+          <path
             fill-rule="evenodd"
             clip-rule="evenodd"
             d="M3 15C3 8.385 8.385 3 15 3s12 5.385 12 12-5.385 12-12 12S3
-            21.615 3 15zm-3 0c0 8.28 6.72 15 15 15 8.28 0 15-6.72 15-15 
+            21.615 3 15zm-3 0c0 8.28 6.72 15 15 15 8.28 0 15-6.72 15-15
             0-8.28-6.72-15-15-15C6.72 0 0 6.72 0 15zm19.5 0l-6 6V9l6 6z"
           />
         `;
       case "time":
         this.viewBox = "0 0 30 30";
         return `
-          <path 
+          <path
             fill-rule="evenodd"
             clip-rule="evenodd"
-            d="M14.985 0C6.705 0 0 6.72 0 15c0 8.28 6.705 15 14.985 15C23.28 30 30 
-            23.28 30 15c0-8.28-6.72-15-15.015-15zM15 27C8.37 27 3 21.63 3 15S8.37 3 
-            15 3s12 5.37 12 12-5.37 12-12 12zm.75-19.5H13.5v9l7.875 4.725L22.5 19.38l-6.75-4.005V7.5z" 
+            d="M14.985 0C6.705 0 0 6.72 0 15c0 8.28 6.705 15 14.985 15C23.28 30 30
+            23.28 30 15c0-8.28-6.72-15-15.015-15zM15 27C8.37 27 3 21.63 3 15S8.37 3
+            15 3s12 5.37 12 12-5.37 12-12 12zm.75-19.5H13.5v9l7.875 4.725L22.5 19.38l-6.75-4.005V7.5z"
           />
         `;
       case "edit":
@@ -165,6 +164,34 @@ export default class Icon extends Vue {
         `;
     }
   }
+
+  mounted() {
+    console.log(this.direction);
+    if (this.direction) this.correctIconDirection();
+  }
+
+  /**
+   * Change direction of Icon, if specified to do so
+   * with an extension to the name of it (-left, -up, etc).
+   */
+  correctIconDirection() {
+    const iconEl = this.$refs.icon as HTMLElement;
+
+    console.log("correcter", this.i);
+
+    // No right direction needed since the icon is right by default
+    switch (this.direction) {
+      case "up":
+        iconEl.classList.add("up");
+        break;
+      case "down":
+        iconEl.classList.add("down");
+        break;
+      case "left":
+        iconEl.classList.add("left");
+        break;
+    }
+  }
 }
 </script>
 
@@ -172,5 +199,17 @@ export default class Icon extends Vue {
 svg {
   // Fix div around SVG being too tall
   display: flex;
+
+  &.left {
+    transform: rotate(180deg);
+  }
+
+  &.up {
+    transform: rotate(270deg);
+  }
+
+  &.down {
+    transform: rotate(90deg);
+  }
 }
 </style>

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -166,7 +166,6 @@ export default class Icon extends Vue {
   }
 
   mounted() {
-    console.log(this.direction);
     if (this.direction) this.correctIconDirection();
   }
 
@@ -176,8 +175,6 @@ export default class Icon extends Vue {
    */
   correctIconDirection() {
     const iconEl = this.$refs.icon as HTMLElement;
-
-    console.log("correcter", this.i);
 
     // No right direction needed since the icon is right by default
     switch (this.direction) {

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -2,7 +2,7 @@
   <div class="btnWrapper">
     <button ref="mainBtn" class="mainBtn">
       <div class="content" @[clickEvent]="$emit('click')">
-        <Icon v-if="icon" :i="icon" />
+        <Icon v-if="icon" :i="icon" :direction="iconDirection" />
 
         <span v-if="text">{{ text }}</span>
 
@@ -36,6 +36,7 @@ import Icon from "./../Icon.vue";
 })
 export default class Button extends Vue {
   @Prop() icon: string;
+  @Prop() iconDirection: string;
   @Prop() text: string;
 
   @Prop({ default: false }) disabled: boolean;

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -124,11 +124,6 @@ export default class Button extends Vue {
   align-items: center;
   height: 100%;
 
-  // Add margin between buttons
-  &:not(:first-child) {
-    margin-left: 5px;
-  }
-
   #outlined {
     padding: 5px;
     border: 2px solid $secondaryColor;

--- a/src/components/ui/DropDown.vue
+++ b/src/components/ui/DropDown.vue
@@ -2,7 +2,7 @@
   <div id="dropDown" class="border-med" @click="toggleDropDown()">
     <label>
       <span>{{ itemActive.name != undefined ? itemActive.name : itemActive }}</span>
-      <Icon i="chevron" wh="16" />
+      <Icon i="chevron" direction="down" wh="16" />
     </label>
 
     <ul ref="dropDownItems" id="dropDownItems">

--- a/src/components/ui/TextBox.vue
+++ b/src/components/ui/TextBox.vue
@@ -6,6 +6,7 @@
       :placeholder="placeholder"
       spellcheck="false"
       @blur="textBoxValueUpdated"
+      :class="{ plain: plain }"
     />
 
     <button v-if="folderSelect" @click="selectFolder">Change</button>
@@ -24,6 +25,12 @@ export default class TextBox extends Vue {
   @Prop() placeholder?: string;
   @Prop({ default: "text" }) type: string;
   @Prop({ default: false }) folderSelect: boolean;
+
+  /**
+   * If TextBox should only appear as such when hovered over.
+   * When not hovered over, it will look like normal text.
+   */
+  @Prop({ default: false }) plain: boolean;
 
   textBoxValue = this.$props.value;
 
@@ -73,6 +80,10 @@ export default class TextBox extends Vue {
     border: none;
     border-radius: 4px;
     transition: background-color 250ms ease;
+
+    &.plain {
+      background-color: transparent;
+    }
 
     &[type="number"]::-webkit-inner-spin-button,
     &[type="number"]::-webkit-outer-spin-button {

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -38,9 +38,9 @@ export default class DefaultLayout extends Vue {
       // If startupPage setting is a page in the application, redirect to it
       // Else go to first page in AppSettings.pages setting
       if (AppSettings.pages.includes(GeneralSettings.startupPage)) {
-        router.push(GeneralSettings.startupPage).catch(() => {});
+        router.push({ name: GeneralSettings.startupPage.toLowerCase() }).catch(() => {});
       } else {
-        router.push(AppSettings.pages[0]).catch(() => {});
+        router.push({ name: AppSettings.pages[0].toLowerCase() }).catch(() => {});
       }
     }
 

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -55,6 +55,11 @@ export default class DefaultLayout extends Vue {
     const tooltip = document.getElementById("tooltip")!;
     let els = document.querySelectorAll("[tooltip]");
 
+    const closeTooltip = () => {
+      tooltip.style.transform = "scale(0.85)";
+      tooltip.style.opacity = "0";
+    };
+
     for (let i = 0, n = els.length; i < n; ++i) {
       let el = els[i] as HTMLElement;
 
@@ -69,10 +74,8 @@ export default class DefaultLayout extends Vue {
         tooltip.style.opacity = "1";
       });
 
-      el.addEventListener("mouseleave", () => {
-        tooltip.style.transform = "scale(0.85)";
-        tooltip.style.opacity = "0";
-      });
+      el.addEventListener("mouseleave", closeTooltip);
+      el.addEventListener("mousedown", closeTooltip);
     }
   }
 }

--- a/src/libs/helpers/extensions/numberExtensions.ts
+++ b/src/libs/helpers/extensions/numberExtensions.ts
@@ -98,8 +98,14 @@ Number.prototype.toInWindowBounds = function(
   if (pos == "x") {
     const width = el.getBoundingClientRect().width;
 
+    // If el goes off right of screen
     if (xy + width > window.innerWidth) {
       xy = window.innerWidth - width - pad;
+    }
+
+    // off left of screen
+    if (xy <= pad) {
+      xy = pad;
     }
   }
 

--- a/src/libs/recorder/recordingsManager.ts
+++ b/src/libs/recorder/recordingsManager.ts
@@ -7,7 +7,6 @@ import ArgumentBuilder from "./argumentBuilder";
 import Notifications from "./../helpers/notifications";
 
 export interface Recording {
-  name: string;
   videoPath: string;
   thumbPath: string | undefined;
   fileSize: number | undefined;
@@ -50,7 +49,6 @@ export default class RecordingsManager {
     const ffprobe = new FFmpeg("ffprobe");
     const recording = {} as Recording;
 
-    recording.name = path.basename(videoPath);
     recording.videoPath = videoPath;
     recording.thumbPath = this.createThumbnail(videoPath);
     recording.fileSize = fs.statSync(videoPath).size;

--- a/src/libs/recorder/recordingsManager.ts
+++ b/src/libs/recorder/recordingsManager.ts
@@ -7,6 +7,7 @@ import ArgumentBuilder from "./argumentBuilder";
 import Notifications from "./../helpers/notifications";
 
 export interface Recording {
+  name: string;
   videoPath: string;
   thumbPath: string | undefined;
   fileSize: number | undefined;
@@ -49,6 +50,7 @@ export default class RecordingsManager {
     const ffprobe = new FFmpeg("ffprobe");
     const recording = {} as Recording;
 
+    recording.name = path.basename(videoPath);
     recording.videoPath = videoPath;
     recording.thumbPath = this.createThumbnail(videoPath);
     recording.fileSize = fs.statSync(videoPath).size;

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,7 +2,7 @@ import Vue from "vue";
 import VueRouter, { RouteConfig } from "vue-router";
 import Videos from "./views/Videos.vue";
 import Settings from "./views/Settings.vue";
-import VideoPlayer from "./views/VideoPlayer.vue";
+import VideoEditor from "./views/VideoEditor.vue";
 import DesktopNotification from "./views/DesktopNotification.vue";
 
 Vue.use(VueRouter);
@@ -19,9 +19,9 @@ const routes: Array<RouteConfig> = [
     component: Settings
   },
   {
-    path: "/videoPlayer/:videoPath",
-    name: "videoPlayer",
-    component: VideoPlayer,
+    path: "/videoEditor/:video",
+    name: "videoEditor",
+    component: VideoEditor,
     props: true
   },
   {

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,9 +9,10 @@ Vue.use(VueRouter);
 
 const routes: Array<RouteConfig> = [
   {
-    path: "/videos",
+    path: "/videos/:subPage?",
     name: "videos",
-    component: Videos
+    component: Videos,
+    props: true
   },
   {
     path: "/settings",

--- a/src/styles/_general.scss
+++ b/src/styles/_general.scss
@@ -5,3 +5,10 @@
 .txt-capitalised {
   text-transform: capitalize;
 }
+
+%m-l-all-not-first {
+  // Add margin between buttons
+  & > *:not(:first-child) {
+    margin-left: 5px;
+  }
+}

--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="videoExists" ref="videoEditor" class="videoEditor">
     <div class="topBar">
-      <Button icon="arrow" iconDirection="left" tooltip="Back To Videos" />
+      <Button icon="arrow" iconDirection="left" tooltip="Back To Videos" @click="$router.go(-1)" />
       <TextBox :value="video.name" :plain="true" class="name"></TextBox>
     </div>
 

--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -1,5 +1,10 @@
 <template>
   <div v-if="videoExists" ref="videoEditor" class="videoEditor">
+    <div class="topBar">
+      <Button icon="arrow" tooltip="Back To Videos" />
+      <TextBox :value="video.name" :plain="true" class="name"></TextBox>
+    </div>
+
     <video
       ref="videoPlayer"
       id="video"
@@ -79,12 +84,13 @@ import ContextMenu from "@/components/context/ContextMenu.vue";
 import ContextItem from "@/components/context/ContextItem.vue";
 import Button from "@/components/ui/Button.vue";
 import ButtonConnector from "@/components/ui/ButtonConnector.vue";
-import "@/libs/helpers/extensions";
+import TextBox from "@/components/ui/TextBox.vue";
 import Helpers from "@/libs/helpers";
 import RecordingsManager, { Recording } from "@/libs/recorder/recordingsManager";
 import fs from "fs";
 import path from "path";
 import noUiSlider, { PipsMode, target } from "nouislider";
+import "@/libs/helpers/extensions";
 
 @Component({
   components: {
@@ -92,7 +98,8 @@ import noUiSlider, { PipsMode, target } from "nouislider";
     ContextMenu,
     ContextItem,
     Button,
-    ButtonConnector
+    ButtonConnector,
+    TextBox
   }
 })
 export default class VideoPlayer extends Vue {
@@ -685,14 +692,28 @@ export default class VideoPlayer extends Vue {
   height: 100%;
   overflow-x: hidden;
 
+  .topBar {
+    @extend %m-l-all-not-first;
+
+    display: flex;
+    flex-flow: row;
+    margin: 5px;
+
+    .name {
+      width: 100%;
+    }
+  }
+
   video {
     width: 100%;
-    height: calc(100% - 90px); // Make height of video all take up all blank space on page
+    height: calc(100% - 134px); // Make height of video all take up all blank space on page
     outline: none;
     background-color: black;
   }
 
   .controls {
+    @extend %m-l-all-not-first;
+
     display: flex;
     align-items: center;
     margin: 5px;

--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -2,7 +2,7 @@
   <div v-if="videoExists" ref="videoEditor" class="videoEditor">
     <div class="topBar">
       <Button icon="arrow" iconDirection="left" tooltip="Back To Videos" @click="$router.go(-1)" />
-      <span>{{ video.name ? video.name : video.videoPath }}</span>
+      <span>{{ require("path").basename(video.videoPath) }}</span>
     </div>
 
     <video

--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="videoExists" ref="videoEditor" class="videoEditor">
     <div class="topBar">
-      <Button icon="arrow" tooltip="Back To Videos" />
+      <Button icon="arrow" iconDirection="left" tooltip="Back To Videos" />
       <TextBox :value="video.name" :plain="true" class="name"></TextBox>
     </div>
 
@@ -68,7 +68,13 @@
           </template>
         </Button>
 
-        <Button icon="arrow" :disabled="continueBtnDisabled" @click="saveClips" tooltip="Continue" />
+        <Button
+          icon="arrow"
+          iconDirection="right"
+          :disabled="continueBtnDisabled"
+          @click="saveClips"
+          tooltip="Continue"
+        />
       </ButtonConnector>
     </div>
   </div>

--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -2,7 +2,7 @@
   <div v-if="videoExists" ref="videoEditor" class="videoEditor">
     <div class="topBar">
       <Button icon="arrow" iconDirection="left" tooltip="Back To Videos" @click="$router.go(-1)" />
-      <span>{{ video.name }}</span>
+      <span>{{ video.name ? video.name : video.videoPath }}</span>
     </div>
 
     <video

--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -2,7 +2,7 @@
   <div v-if="videoExists" ref="videoEditor" class="videoEditor">
     <div class="topBar">
       <Button icon="arrow" iconDirection="left" tooltip="Back To Videos" @click="$router.go(-1)" />
-      <TextBox :value="video.name" :plain="true" class="name"></TextBox>
+      <span>{{ video.name }}</span>
     </div>
 
     <video
@@ -703,6 +703,7 @@ export default class VideoPlayer extends Vue {
 
     display: flex;
     flex-flow: row;
+    align-items: center;
     margin: 5px;
 
     .name {

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -41,7 +41,7 @@
 
               <div class="bar">
                 <span class="title">
-                  <p>{{ vid.name }}</p>
+                  <p>{{ vid.name ? vid.name : vid.videoPath }}</p>
                 </span>
 
                 <div class="videoInfo">

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -19,7 +19,7 @@
       </div>
 
       <div class="thumbContainer" v-if="videos.length > 0">
-        <div class="thumb" v-for="vid in loadedRecordings" :key="vid.id">
+        <div class="thumb" v-for="vid in loadedVideos" :key="vid.id">
           <div class="inner">
             <!-- If thumbPath is an actual file display it, otherwise, display noThumb message -->
             <img
@@ -35,7 +35,7 @@
                 <p>FPS</p>
               </span>
 
-              <router-link :to="{ name: 'videoPlayer', params: { videoPath: vid.videoPath } }" class="edit">
+              <router-link :to="{ name: 'videoEditor', params: { video: vid } }" class="edit">
                 <Icon i="edit" :wh="25" />
               </router-link>
 
@@ -84,7 +84,7 @@ export default class extends Vue {
   allRecordings = RecordingsManager.get();
   allClips = RecordingsManager.get(true);
   videos = this.allRecordings;
-  loadedRecordings = new Array();
+  loadedVideos = new Array();
 
   dropZoneHidden = true;
   dragEnterTarget: EventTarget | null = null;
@@ -104,7 +104,7 @@ export default class extends Vue {
 
   @Watch("activeSubPage")
   subPageChanged(val: subPage) {
-    this.loadedRecordings = [];
+    this.loadedVideos = [];
 
     if (val == "recordings") {
       this.videos = this.allRecordings;
@@ -122,10 +122,10 @@ export default class extends Vue {
     // How many videos to load in
     let videosToLoad = 8;
 
-    // Loop over videos after removing currently loaded recordings adding to loadedRecordings
-    for (let [i, v] of this.videos.slice(this.loadedRecordings.length).entries()) {
-      // Add to loadedRecordings
-      this.loadedRecordings.push(v);
+    // Loop over videos after removing currently loaded recordings adding to loadedVideos
+    for (let [i, v] of this.videos.slice(this.loadedVideos.length).entries()) {
+      // Add to loadedVideos
+      this.loadedVideos.push(v);
 
       // Stop for loop if index >= videosToLoad
       if (i >= videosToLoad) return;

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -203,14 +203,14 @@ export default class extends Vue {
   display: flex;
   flex-flow: column;
   align-items: center;
-  min-height: calc(100% - 20px);
+  min-height: calc(100% - 24px);
   margin: 12px 20px;
 
   .wrapper {
     width: 100%;
     max-width: 1600px;
 
-    & > div:not(.dropZone) {
+    & > div:not(.dropZone):not(:last-child) {
       margin-bottom: 12px;
     }
 

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -96,7 +96,7 @@ export default class extends Vue {
     let el = document.getElementById("main");
     el?.addEventListener("scroll", () => {
       // If scrolled to bottom loadMoreRecordings
-      if (el?.scrollHeight! - el?.scrollTop! === el?.clientHeight) {
+      if (el?.scrollHeight! - el?.scrollTop! === el?.clientHeight!) {
         this.loadMoreRecordings();
       }
     });

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -41,7 +41,7 @@
 
               <div class="bar">
                 <span class="title">
-                  <p>{{ vid.name ? vid.name : vid.videoPath }}</p>
+                  <p>{{ require("path").basename(vid.videoPath) }}</p>
                 </span>
 
                 <div class="videoInfo">

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -8,14 +8,14 @@
   >
     <div class="wrapper">
       <div class="viewToggler">
-        <span
+        <router-link
           v-for="page in subPages"
           :key="page"
-          :class="{ active: page == activeSubPage }"
-          @click="activeSubPage = page"
+          :to="{ name: 'videos', params: { subPage: page } }"
+          :class="{ active: page == subPage }"
         >
           {{ page }}
-        </span>
+        </router-link>
       </div>
 
       <div class="thumbContainer" v-if="videos.length > 0">
@@ -53,18 +53,18 @@
           </div>
         </div>
       </div>
-      <span v-else class="noRecordings txt-capitalised">You Have No {{ activeSubPage }}!</span>
+      <span v-else class="noRecordings txt-capitalised">You Have No {{ subPage }}!</span>
     </div>
 
     <div :class="{ dropZone: true, hidden: dropZoneHidden }">
       <Icon i="add" wh="36" />
-      <span class="txt-capitalised">Add {{ activeSubPage }}</span>
+      <span class="txt-capitalised">Add {{ subPage }}</span>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { Vue, Component, Watch } from "vue-property-decorator";
+import { Vue, Component, Watch, Prop } from "vue-property-decorator";
 import Icon from "@/components/Icon.vue";
 import RecordingsManager from "@/libs/recorder/recordingsManager";
 import "@/libs/helpers/extensions";
@@ -78,12 +78,13 @@ type subPage = typeof subPages[number];
   }
 })
 export default class extends Vue {
+  @Prop({ default: "recordings" }) subPage: subPage;
+
   subPages = subPages;
-  activeSubPage: subPage = "recordings";
 
   allRecordings = RecordingsManager.get();
   allClips = RecordingsManager.get(true);
-  videos = this.allRecordings;
+  videos = this.$props.subPage == "recordings" ? this.allRecordings : this.allClips;
   loadedVideos = new Array();
 
   dropZoneHidden = true;
@@ -102,7 +103,7 @@ export default class extends Vue {
     });
   }
 
-  @Watch("activeSubPage")
+  @Watch("subPage")
   subPageChanged(val: subPage) {
     this.loadedVideos = [];
 
@@ -225,7 +226,7 @@ export default class extends Vue {
       align-self: flex-start;
       font-size: 28px;
 
-      span {
+      a {
         text-transform: capitalize;
         cursor: pointer;
 

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -41,7 +41,7 @@
 
               <div class="bar">
                 <span class="title">
-                  <p>{{ vid.videoPath }}</p>
+                  <p>{{ vid.name }}</p>
                 </span>
 
                 <div class="videoInfo">


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Create back button and show video file names instead of full path for their names.

Also:
- Fix going to default page, was going to non-existent page.
- Add `direction` directive to the Icon component.
- Fix tooltips going off left of window.
- Close tooltips on `mousedown` instead of only `mouseleave` (if element tooltip is applied to disappears, you can't move mouse off it).

Closes #199 