### PR TITLE
Fix height calc on video when timeline is zoomed

### DIFF
--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -730,7 +730,7 @@ export default class VideoPlayer extends Vue {
 
   &.timelineZoomed {
     video {
-      height: calc(100% - 95px); // Make height of video all take up all blank space on page
+      height: calc(100% - 139px); // Make height of video all take up all blank space on page
     }
 
     .timeline {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
Fix height calc on video when timeline is zoomed
