### PR TITLE
Make name of video and let if be edited.

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -20,7 +20,7 @@ const routes: Array<RouteConfig> = [
     component: Settings
   },
   {
-    path: "/videoEditor/:video",
+    path: "/videoEditor/:video/:isClip",
     name: "videoEditor",
     component: VideoEditor,
     props: true

--- a/src/views/VideoEditor.vue
+++ b/src/views/VideoEditor.vue
@@ -2,7 +2,12 @@
   <div v-if="videoExists" ref="videoEditor" class="videoEditor">
     <div class="topBar m-l-all-not-first">
       <Button icon="arrow" iconDirection="left" tooltip="Back To Videos" @click="$router.go(-1)" />
-      <span>{{ require("path").basename(video.videoPath) }}</span>
+      <TextBox
+        name="videoName"
+        :value="video.name ? video.name : video.videoPath"
+        @item-changed="updateVideoName"
+        class="name"
+      />
     </div>
 
     <video
@@ -110,6 +115,7 @@ import "@/libs/helpers/extensions";
 })
 export default class VideoPlayer extends Vue {
   @Prop({ required: true }) video: Recording;
+  @Prop({ required: true }) isClip: boolean;
 
   private player: HTMLVideoElement;
   private videoEditor: target;
@@ -139,6 +145,10 @@ export default class VideoPlayer extends Vue {
       // loaded yet, so it's value will be 0 anyways.
       return 0;
     }
+  }
+
+  updateVideoName(_: any, newValue: string) {
+    RecordingsManager.rename(this.video.videoPath, newValue, this.isClip);
   }
 
   /**

--- a/src/views/Videos.vue
+++ b/src/views/Videos.vue
@@ -35,13 +35,16 @@
                 <p>FPS</p>
               </span>
 
-              <router-link :to="{ name: 'videoEditor', params: { video: vid } }" class="edit">
+              <router-link
+                :to="{ name: 'videoEditor', params: { video: vid, isClip: subPage == 'clips' } }"
+                class="edit"
+              >
                 <Icon i="edit" :wh="25" />
               </router-link>
 
               <div class="bar">
                 <span class="title">
-                  <p>{{ require("path").basename(vid.videoPath) }}</p>
+                  <p>{{ vid.name ? vid.name : vid.videoPath }}</p>
                 </span>
 
                 <div class="videoInfo">


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
- Create `toWritingReady()` to turn a JSON object into one that can be written to a video file.
- Create `getVideos()` to get all videos from a video file and turn it into a real JSON object.
- Create `rename()` to handle renaming videos.
- By default, set name of video to the videos file name. Show this name if it exists, otherwise show full path. No reason for it not to show, mostly for people with video files being migrated to this version.
- Videos in video files are now stored minified, instead of formatted.

Closes #206 
