### PR TITLE
Scrubber lock

### DIFF
--- a/src/common/Button.tsx
+++ b/src/common/Button.tsx
@@ -9,13 +9,25 @@ interface ButtonProps extends CommonComponentProps {
   text?: string;
   disabled?: boolean;
   outlined?: boolean;
+  active?: boolean;
   slider?: SliderProps;
   children?: React.ReactNode;
   onClick?: () => void;
 }
 
 export default function Button(props: ButtonProps) {
-  const { icon, iconDirection, text, disabled = false, outlined = false, slider, children, onClick, className } = props;
+  const {
+    icon,
+    iconDirection,
+    text,
+    disabled = false,
+    outlined = false,
+    slider,
+    children,
+    onClick,
+    className,
+    active = true
+  } = props;
 
   const btnClasses = !outlined ? "bg-secondary-100 enabled:hover:bg-transparent" : "enabled:hover:bg-secondary-100";
   const sliderOpenClasses = "ml-1.5 mr-2";
@@ -24,9 +36,11 @@ export default function Button(props: ButtonProps) {
 
   return (
     <button
-      className={`flex items-center justify-center p-1.5 ${btnClasses} w-auto rounded border-2 border-secondary-100 ${
+      className={`flex items-center justify-center p-1.5 w-auto rounded border-2 border-secondary-100 ${
         className ?? ""
-      } transition-colors disabled:bg-tertiary-100 disabled:cursor-not-allowed`}
+      } transition-colors disabled:bg-tertiary-100 disabled:cursor-not-allowed ${
+        active ? btnClasses : "bg-tertiary-100"
+      }`}
       onMouseEnter={() => setSliderClasses(sliderOpenClasses)}
       onMouseLeave={() => setSliderClasses(sliderClosedClasses)}
       disabled={disabled}

--- a/src/common/Icon.tsx
+++ b/src/common/Icon.tsx
@@ -30,7 +30,8 @@ export type Icons =
   | "clips"
   | "time"
   | "edit"
-  | "search";
+  | "search"
+  | "pin";
 
 export type IconDirection = "up" | "down" | "left" | "right";
 
@@ -276,6 +277,28 @@ function getIcon(name: Icons): { viewBox: string; el: JSX.Element } {
               strokeMiterlimit="10"
               strokeWidth="32"
               d="M338.29 338.29L448 448"
+            />
+          </g>
+        )
+      };
+    case "pin":
+      return {
+        viewBox: "0 0 512 512",
+        el: (
+          <g>
+            <circle
+              cx="256"
+              cy="96"
+              r="64"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="32"
+            />
+            <path
+              fill="currentColor"
+              d="M272 164a9 9 0 00-9-9h-14a9 9 0 00-9 9v293.56a32.09 32.09 0 002.49 12.38l10.07 24a3.92 3.92 0 006.88 0l10.07-24a32.09 32.09 0 002.49-12.38z"
             />
           </g>
         )

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -55,7 +55,9 @@ export default function VideoEditor() {
     addClip,
     playClips,
     isPlayingClips,
-    adjustZoom
+    adjustZoom,
+    lockOnScrubber,
+    setLockOnScrubber
   } = useEditor(playerRef, timelineRef, progressBarRef, clipsBarRef);
 
   return (
@@ -144,6 +146,7 @@ export default function VideoEditor() {
         <Button text="Add Clip" onClick={addClip} />
         <Button icon="add" onClick={() => adjustZoom(true)} />
         <Button icon="min2" onClick={() => adjustZoom(false)} />
+        <Button icon="pin" active={lockOnScrubber} onClick={() => setLockOnScrubber(!lockOnScrubber)} />
         <div className="ml-auto"></div>
         <ButtonConnector>
           <Button outlined={true} onClick={playClips} className="relative">

--- a/src/editor/useEditor.ts
+++ b/src/editor/useEditor.ts
@@ -22,6 +22,7 @@ export default function useEditor(
   const [renderBtnDisabled, setRenderBtnDisabled] = useState<boolean>(true);
   const [isPlayingClips, setIsPlayingClips] = useState<boolean>(false); // Setting this to false will ensure clip playing stops
   const [timelineZoom, setTimelineZoom] = useState<number>(100);
+  const [lockOnScrubber, setLockOnScrubber] = useState<boolean>(false);
 
   let player = playerRef.current!;
   let timeline = timelineRef.current!;
@@ -50,9 +51,18 @@ export default function useEditor(
   }, []);
 
   // Update when playerCurTime/showTimeAsElapsed changes.
-  // Currently just updates the readable video time.
+  // Currently updates the readable video time and includes lockOnScrubber functionality.
   useEffect(() => {
     updateVideoTimeReadable();
+
+    if (lockOnScrubber) {
+      const scrubber = progressBar.noUiSlider?.getOrigins()[0].querySelector(".noUi-handle");
+      if (scrubber) {
+        timeline.scrollTo({
+          left: timeline.scrollLeft + scrubber.getBoundingClientRect().x - timeline.getBoundingClientRect().width / 2
+        });
+      }
+    }
   }, [playerCurTime, showTimeAsElapsed]);
 
   useEffect(() => {
@@ -553,6 +563,8 @@ export default function useEditor(
     addClip,
     playClips,
     isPlayingClips,
-    adjustZoom
+    adjustZoom,
+    lockOnScrubber,
+    setLockOnScrubber
   };
 }

--- a/src/editor/useEditor.ts
+++ b/src/editor/useEditor.ts
@@ -57,7 +57,7 @@ export default function useEditor(
   useEffect(() => {
     updateVideoTimeReadable();
 
-    if (lockOnScrubber) {
+    if (!player.paused && lockOnScrubber) {
       const scrubber = progressBar.noUiSlider?.getOrigins()[0].querySelector(".noUi-handle");
       if (scrubber) {
         timeline.scrollTo({
@@ -144,7 +144,7 @@ export default function useEditor(
    * Disable lock on scrubber if user clicks on timeline.
    */
   const timelineClick = () => {
-    setLockOnScrubber(false);
+    if (!player.paused) setLockOnScrubber(false);
   };
 
   /**

--- a/src/editor/useEditor.ts
+++ b/src/editor/useEditor.ts
@@ -40,12 +40,14 @@ export default function useEditor(
       player.addEventListener("play", updatePlayBtnIcon);
       player.addEventListener("pause", updatePlayBtnIcon);
       player.addEventListener("timeupdate", videoTimeUpdate);
+      timeline.addEventListener("click", timelineClick);
 
       return () => {
         player.removeEventListener("loadedmetadata", videoLoaded);
         player.removeEventListener("play", updatePlayBtnIcon);
         player.removeEventListener("pause", updatePlayBtnIcon);
         player.removeEventListener("timeupdate", videoTimeUpdate);
+        timeline.removeEventListener("click", timelineClick);
       };
     }
   }, []);
@@ -136,6 +138,13 @@ export default function useEditor(
         addClip();
       });
     }
+  };
+
+  /**
+   * Disable lock on scrubber if user clicks on timeline.
+   */
+  const timelineClick = () => {
+    setLockOnScrubber(false);
   };
 
   /**


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->

- Button now has `active` prop.
- New `pin` icon.
- New button in Editor for locking timeline on scrubber whilst video is playing.

