### PR TITLE
Editor keybinds

### DIFF
--- a/src/common/Tooltip.tsx
+++ b/src/common/Tooltip.tsx
@@ -44,7 +44,7 @@ export default function Tooltip({ text, children }: TooltipProps) {
       <div ref={childRef}>{children}</div>
       <span
         ref={tooltipRef}
-        className="opacity-0 absolute top-[-35px] px-2 py-1 whitespace-nowrap bg-quaternary-200 rounded shadow transition-[transform,opacity] transition-opacity"
+        className="opacity-0 absolute top-[-35px] px-2 py-1 whitespace-nowrap bg-quaternary-200 rounded shadow transition-[transform,opacity] transition-opacity z-40"
       >
         {text}
       </span>

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -147,13 +147,13 @@ export default function VideoEditor() {
         />
         <Button text={videoTimeReadable} outlined={true} onClick={() => toggleShowTimeAsElapsed()} />
         <Button text="Add Clip" onClick={addClip} />
-        <Tooltip text="Zoom In">
+        <Tooltip text="Zoom In (Z)">
           <Button icon="add" onClick={() => adjustZoom(true)} />
         </Tooltip>
-        <Tooltip text="Zoom Out">
+        <Tooltip text="Zoom Out (X)">
           <Button icon="min2" onClick={() => adjustZoom(false)} />
         </Tooltip>
-        <Tooltip text="Toggle Lock On Scrubber">
+        <Tooltip text="Toggle Lock On Scrubber (S)">
           <Button icon="pin" active={lockOnScrubber} onClick={() => setLockOnScrubber(!lockOnScrubber)} />
         </Tooltip>
         <div className="ml-auto"></div>


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made

Added local keybinds to editor (+ quickfix for tooltips showing under scrubber):

- Play/Pause (Space)
- Volume control (ArrowUp/ArrowDown)
- Skip forwards/back 5s (ArrowRight/ArrowLeft)
- Add clip (C)
- Remove clip that scrubber is inside (Ctrl+C)
- Toggle lock on scrubber (S)
- Toggle mute (M)
- Zoom in (Z)
- Zoom out (X)

Closes #354 
