### PR TITLE
Fix dnotif path for built app

### DIFF
--- a/entry/background.ts
+++ b/entry/background.ts
@@ -110,7 +110,9 @@ function registerChannels(win: BrowserWindow) {
       await notifWin.loadURL(`${process.env.SERVER_URL}/index.html#/dnotif/${args.icon}/${args.desc}`);
     } else {
       // Load the index.html when not in development
-      await notifWin.loadURL(`file://${path.join(__dirname, `index.html#dnotif/${args.icon}/${args.desc}`)}`); // TEST THIS IN A BUILD
+      await notifWin.loadURL(
+        `file://${path.join(__dirname, `../../dist/vi/index.html#/dnotif/${args.icon}/${args.desc}`)}`
+      );
     }
 
     // Close window after defined duration


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->
Fixes desktop notification not showing in the built app. 

Closes #379 