### PR TITLE
Persistent video volume

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -19,7 +19,8 @@ export const DEFAULT_SETTINGS = {
     rcStatusAlsoStopStart: true,
     rcStatusDblClkToRecord: false,
     deleteVideoConfirmationDisabled: false,
-    deleteVideosFromDisk: false
+    deleteVideosFromDisk: false,
+    videoEditorVolume: 0.8
   },
   recording: {
     thumbSaveFolder: path.join(Paths.mainFolderPath, "Thumbs"),

--- a/src/common/Button.tsx
+++ b/src/common/Button.tsx
@@ -59,6 +59,7 @@ export default function Button(props: ButtonProps) {
             step={slider.step}
             wheelStep={slider.wheelStep}
             onChange={slider.onChange}
+            onFinishedChanging={slider.onFinishedChanging}
           />
         </div>
       )}

--- a/src/common/Slider.tsx
+++ b/src/common/Slider.tsx
@@ -5,21 +5,30 @@ export interface SliderProps {
   step?: number;
   wheelStep?: number;
   onChange: (newVal: number) => void;
+
+  /**
+   * When the user is done changing the volume (mouse up, wheel events).
+   * This can be used kind of like onBlur, so we know when we can do an intensive operation on the new value.
+   */
+  onFinishedChanging: (newVal: number) => void;
 }
 
 export default function Slider(props: SliderProps) {
-  const { value = 0, min = 0, max = 100, step = 1, wheelStep = 1, onChange } = props;
+  const { value = 0, min = 0, max = 100, step = 1, wheelStep = 1, onChange, onFinishedChanging } = props;
 
   const onWheel = (ev: React.WheelEvent<HTMLInputElement>) => {
+    let newVolume = max;
     if (ev.deltaY < 0) {
       const newVal = Number((value + wheelStep).toFixed(2));
-      if (newVal < 1) onChange(newVal);
-      else onChange(max);
+      if (newVal < 1) newVolume = newVal;
+      else newVolume = max;
     } else {
       const newVal = Number((value - wheelStep).toFixed(2));
-      if (newVal >= 0) onChange(newVal);
-      else onChange(min);
+      if (newVal >= 0) newVolume = newVal;
+      else newVolume = min;
     }
+    onChange(newVolume);
+    onFinishedChanging(newVolume);
   };
 
   return (
@@ -31,6 +40,7 @@ export default function Slider(props: SliderProps) {
       step={step}
       onChange={(ev) => onChange(Number(ev.target.value))}
       onWheel={onWheel}
+      onMouseUp={(ev) => onFinishedChanging(Number((ev.target as HTMLInputElement).value))}
       className="w-full"
     />
   );

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -17,6 +17,7 @@ import { RootState } from "@/app/store";
 import { toReadableTimeFromSeconds } from "@/libs/helpers/extensions/number";
 import Tooltip from "@/common/Tooltip";
 import { logger } from "@/libs/logger";
+import { setVideoEditorVolume } from "@/settings/settingsSlice";
 
 export default function VideoEditor() {
   const navigate = useNavigate();
@@ -60,7 +61,7 @@ export default function VideoEditor() {
     adjustZoom,
     lockOnScrubber,
     setLockOnScrubber
-  } = useEditor(playerRef, timelineRef, progressBarRef, clipsBarRef);
+  } = useEditor(playerRef, timelineRef, progressBarRef, clipsBarRef, genState.videoEditorVolume);
 
   return (
     <div className="flex h-[calc(100vh_-_77px)] flex-col gap-1.5 my-1.5 h-full">
@@ -142,9 +143,15 @@ export default function VideoEditor() {
             wheelStep: 0.1,
             onChange: (val) => {
               updateVolume(val);
+            },
+            onFinishedChanging: (val) => {
+              dispatch(setVideoEditorVolume(val));
             }
           }}
-          onClick={toggleMute}
+          onClick={() => {
+            const newVol = toggleMute();
+            dispatch(setVideoEditorVolume(newVol));
+          }}
         />
         <Button text={videoTimeReadable} outlined={true} onClick={() => toggleShowTimeAsElapsed()} />
         <Button text="Add Clip" onClick={addClip} />

--- a/src/editor/useEditor.ts
+++ b/src/editor/useEditor.ts
@@ -10,7 +10,8 @@ export default function useEditor(
   playerRef: React.RefObject<HTMLVideoElement>,
   timelineRef: React.RefObject<HTMLDivElement>,
   progressBarRef: React.RefObject<HTMLDivElement>,
-  clipsBarRef: React.RefObject<HTMLDivElement>
+  clipsBarRef: React.RefObject<HTMLDivElement>,
+  initialVolume: number
 ) {
   const [playBtnIcon, setPlayBtnIcon] = useState<"play" | "pause">("play");
   const [volume, setVolume] = useState<number>(0.8);
@@ -100,9 +101,7 @@ export default function useEditor(
    */
   const videoLoaded = () => {
     logger.info("Editor", "VIDEO LOADED");
-    // TODO volume should be stored in state (settings?) and restored - volume being reset to default when looking at diff clips is not nice
-    updateVolume(0.8); // Set default volume and icon
-
+    updateVolume(initialVolume); // Set default volume and icon
     updateVideoTimeReadable();
 
     if (!progressBar.classList.contains("noUi-target")) {
@@ -623,8 +622,10 @@ export default function useEditor(
   const toggleMute = () => {
     if (volume > 0) {
       updateVolume(0);
+      return 0;
     } else {
       updateVolume(0.5);
+      return 0.5;
     }
   };
 

--- a/src/settings/settingsSlice.ts
+++ b/src/settings/settingsSlice.ts
@@ -24,6 +24,9 @@ const settingsSlice = createSlice({
     setDeleteVideosFromDisk(state, action: PayloadAction<boolean>) {
       state.general.deleteVideosFromDisk = action.payload;
     },
+    setVideoEditorVolume(state, action: PayloadAction<number>) {
+      state.general.videoEditorVolume = action.payload;
+    },
 
     //
     // Recording Settings
@@ -86,6 +89,7 @@ export const {
   setRcStatusDblClkToRecord,
   setDeleteVideoConfirmationDisabled,
   setDeleteVideosFromDisk,
+  setVideoEditorVolume,
 
   setThumbSaveFolder,
   setVideoSaveFolder,

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -32,6 +32,11 @@ export interface GeneralSettings {
    * in Casterr.
    */
   deleteVideosFromDisk: boolean;
+
+  /**
+   * Video editor volume.
+   */
+  videoEditorVolume: number;
 }
 
 export interface RecordingSettings {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->
- Store video volume in settings and state so its persistent across all videos and restarts

Closes #364 