### PR TITLE
Bookmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@reduxjs/toolkit": "^1.9.1",
         "axios": "^1.6.0",
         "electron-updater": "^5.3.0",
-        "nouislider": "^15.6.1",
+        "nouislider": "^15.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.2",
@@ -6103,9 +6103,9 @@
       }
     },
     "node_modules/nouislider": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.6.1.tgz",
-      "integrity": "sha512-1T5AfeEMGrGM87UJ+qAHvauPfCe/woOjYV/o29fp21+XgGuGpkM1Udo7mPHnidu4+cxlj35rDBWKiA6Mefemrg=="
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.7.1.tgz",
+      "integrity": "sha512-5N7C1ru/i8y3dg9+Z6ilj6+m1EfabvOoaRa7ztpxBSKKRZso4vA52DGSbBJjw5XLtFr/LZ9SgGAXqyVtlVHO5w=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -12647,9 +12647,9 @@
       "dev": true
     },
     "nouislider": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.6.1.tgz",
-      "integrity": "sha512-1T5AfeEMGrGM87UJ+qAHvauPfCe/woOjYV/o29fp21+XgGuGpkM1Udo7mPHnidu4+cxlj35rDBWKiA6Mefemrg=="
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.7.1.tgz",
+      "integrity": "sha512-5N7C1ru/i8y3dg9+Z6ilj6+m1EfabvOoaRa7ztpxBSKKRZso4vA52DGSbBJjw5XLtFr/LZ9SgGAXqyVtlVHO5w=="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@reduxjs/toolkit": "^1.9.1",
     "axios": "^1.6.0",
     "electron-updater": "^5.3.0",
-    "nouislider": "^15.6.1",
+    "nouislider": "^15.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -39,6 +39,7 @@ export const DEFAULT_SETTINGS = {
   },
   key: {
     startStopRecording: "F9",
-    startStopRecordingRegion: "F10"
+    startStopRecordingRegion: "F10",
+    addBookmark: "F2"
   }
 } as Settings;

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -43,19 +43,16 @@ const saver = (store: any) => (next: Dispatch<AnyAction>) => async (action: AnyA
       const isClip = action.payload.isClip;
       logger.info("saver", "Video state changed, writing changes to file. isClip:", isClip);
       if (isClip === true || isClip === false) {
+        const f = await PathHelper.getFile(isClip ? "clips" : "recordings");
         if (action.type.includes("videos/videoAdded")) {
           // Actions where should append to file instead of replace all
-          await fs.appendFile(
-            await PathHelper.getFile(isClip ? "clips" : "recordings"),
-            RecordingsManager.toWritingReady(action.payload, true)
-          );
+          await fs.appendFile(f, RecordingsManager.toWritingReady(action.payload, true));
         } else {
           const vidState = store.getState().videos;
+          const tow = RecordingsManager.toWritingReady(isClip ? vidState.clips : vidState.recordings, false);
           // Default to replace file for all other actions
-          await fs.writeFile(
-            await PathHelper.getFile(isClip ? "clips" : "recordings"),
-            RecordingsManager.toWritingReady(isClip ? vidState.clips : vidState.recordings, false)
-          );
+          console.log("saving videos", f, tow);
+          await fs.writeFile(f, tow);
         }
       } else {
         logger.error(

--- a/src/common/Icon.tsx
+++ b/src/common/Icon.tsx
@@ -36,7 +36,8 @@ export type Icons =
   | "wifi"
   | "globe"
   | "youtube"
-  | "folder";
+  | "folder"
+  | "bookmark";
 
 export type IconDirection = "up" | "down" | "left" | "right";
 
@@ -406,6 +407,20 @@ function getIcon(name: Icons): { viewBox: string; el: JSX.Element } {
           <path
             fill="currentColor"
             d="M408 96H252.11a23.89 23.89 0 01-13.31-4L211 73.41A55.77 55.77 0 00179.89 64H104a56.06 56.06 0 00-56 56v24h416c0-30.88-25.12-48-56-48zM423.75 448H88.25a56 56 0 01-55.93-55.15L16.18 228.11v-.28A48 48 0 0164 176h384.1a48 48 0 0147.8 51.83v.28l-16.22 164.74A56 56 0 01423.75 448zm56.15-221.45z"
+          />
+        )
+      };
+    case "bookmark":
+      return {
+        viewBox: "0 0 512 512",
+        el: (
+          <path
+            d="M352 48H160a48 48 0 00-48 48v368l144-128 144 128V96a48 48 0 00-48-48z"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="32"
           />
         )
       };

--- a/src/common/Tooltip.tsx
+++ b/src/common/Tooltip.tsx
@@ -20,6 +20,7 @@ export default function Tooltip(props: TooltipProps) {
       tooltipRef.current.style.top = `${er.top - er.height - gap}px`;
       tooltipRef.current.style.left = `${toInWindowBounds(er.left, "x", tooltipRef.current, childRef.current)}px`;
       tooltipRef.current.style.opacity = "1";
+      tooltipRef.current.style.pointerEvents = "unset";
     }
   };
 
@@ -27,6 +28,7 @@ export default function Tooltip(props: TooltipProps) {
     if (childRef.current && tooltipRef.current) {
       tooltipRef.current.style.transform = "scale(0.85)";
       tooltipRef.current.style.opacity = "0";
+      tooltipRef.current.style.pointerEvents = "none";
     }
   };
 

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -11,7 +11,7 @@ import "./editor.scss";
 import type { Video } from "@/videos/types";
 import RecordingsManager from "@/libs/recorder/recordingsManager";
 import { useDispatch, useSelector } from "react-redux";
-import { videoRenamed } from "@/videos/videosSlice";
+import { videoBookmarkAdded, videoRenamed } from "@/videos/videosSlice";
 import Notifications from "@/libs/helpers/notifications";
 import { type RootState } from "@/app/store";
 import { toReadableTimeFromSeconds } from "@/libs/helpers/extensions/number";
@@ -38,6 +38,10 @@ export default function VideoEditor() {
       .catch((e) => logger.error("Editor", "Unable to verify video files existence.", e));
   }, [video.videoPath]);
 
+  const onBookmarkAdded = (bookmark: number) => {
+    dispatch(videoBookmarkAdded({ videoPath: video.videoPath, isClip: video.isClip, bookmark }));
+  };
+
   const playerRef = useRef<HTMLVideoElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
   const progressBarRef = useRef<HTMLDivElement>(null);
@@ -63,7 +67,16 @@ export default function VideoEditor() {
     lockOnScrubber,
     setLockOnScrubber,
     addBookmark
-  } = useEditor(playerRef, timelineRef, progressBarRef, clipsBarRef, bookmarksBarRef, genState.videoEditorVolume);
+  } = useEditor(
+    playerRef,
+    timelineRef,
+    progressBarRef,
+    clipsBarRef,
+    bookmarksBarRef,
+    genState.videoEditorVolume,
+    onBookmarkAdded,
+    video.bookmarks
+  );
 
   return (
     <div className="flex flex-col gap-1.5 my-1.5 h-[calc(100vh-77px)]">

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -11,7 +11,7 @@ import "./editor.scss";
 import type { Video } from "@/videos/types";
 import RecordingsManager from "@/libs/recorder/recordingsManager";
 import { useDispatch, useSelector } from "react-redux";
-import { videoBookmarkAdded, videoRenamed } from "@/videos/videosSlice";
+import { videoBookmarkAdded, videoBookmarkRemoved, videoRenamed } from "@/videos/videosSlice";
 import Notifications from "@/libs/helpers/notifications";
 import { type RootState } from "@/app/store";
 import { toReadableTimeFromSeconds } from "@/libs/helpers/extensions/number";
@@ -40,6 +40,10 @@ export default function VideoEditor() {
 
   const onBookmarkAdded = (bookmark: number) => {
     dispatch(videoBookmarkAdded({ videoPath: video.videoPath, isClip: video.isClip, bookmark }));
+  };
+
+  const onBookmarkRemoved = (bookmark: number) => {
+    dispatch(videoBookmarkRemoved({ videoPath: video.videoPath, isClip: video.isClip, bookmark }));
   };
 
   const playerRef = useRef<HTMLVideoElement>(null);
@@ -75,6 +79,7 @@ export default function VideoEditor() {
     bookmarksBarRef,
     genState.videoEditorVolume,
     onBookmarkAdded,
+    onBookmarkRemoved,
     video.bookmarks
   );
 

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -42,6 +42,7 @@ export default function VideoEditor() {
   const timelineRef = useRef<HTMLDivElement>(null);
   const progressBarRef = useRef<HTMLDivElement>(null);
   const clipsBarRef = useRef<HTMLDivElement>(null);
+  const bookmarksBarRef = useRef<HTMLDivElement>(null);
   const {
     clipsBar,
     playPause,
@@ -60,8 +61,9 @@ export default function VideoEditor() {
     isPlayingClips,
     adjustZoom,
     lockOnScrubber,
-    setLockOnScrubber
-  } = useEditor(playerRef, timelineRef, progressBarRef, clipsBarRef, genState.videoEditorVolume);
+    setLockOnScrubber,
+    addBookmark
+  } = useEditor(playerRef, timelineRef, progressBarRef, clipsBarRef, bookmarksBarRef, genState.videoEditorVolume);
 
   return (
     <div className="flex flex-col gap-1.5 my-1.5 h-[calc(100vh-77px)]">
@@ -135,6 +137,7 @@ export default function VideoEditor() {
       <div ref={timelineRef} className="timeline">
         <div ref={progressBarRef} id="progressBar" className="progressBar"></div>
         <div ref={clipsBarRef} id="clipsBar" className="clipsBar"></div>
+        <div ref={bookmarksBarRef} id="bookmarksBar" className="bookmarksBar"></div>
       </div>
 
       <div className="flex gap-1.5 mx-1.5">
@@ -180,6 +183,14 @@ export default function VideoEditor() {
             icon="min2"
             onClick={() => {
               adjustZoom(false);
+            }}
+          />
+        </Tooltip>
+        <Tooltip text="Bookmark (B)">
+          <Button
+            icon="bookmark"
+            onClick={() => {
+              addBookmark();
             }}
           />
         </Tooltip>

--- a/src/editor/editor.scss
+++ b/src/editor/editor.scss
@@ -161,9 +161,10 @@
     .noUi-handle {
       height: 40px;
       border: 0;
-      pointer-events: none;
       width: 2px;
       background-color: orange;
+      pointer-events: all;
+      cursor: default;
 
       &::before {
         content: "";
@@ -178,6 +179,14 @@
         border-left: 5px solid transparent;
         border-right: 5px solid transparent;
         border-bottom: 5px solid transparent;
+      }
+
+      &:hover {
+        background-color: #c10000;
+
+        &::before {
+          border-top-color: #c10000;
+        }
       }
     }
   }

--- a/src/editor/editor.scss
+++ b/src/editor/editor.scss
@@ -147,4 +147,38 @@
       pointer-events: none;
     }
   }
+
+  .bookmarksBar {
+    position: relative;
+    top: -200%;
+    height: 100%;
+    background-color: transparent;
+
+    .noUi-base {
+      pointer-events: none;
+    }
+
+    .noUi-handle {
+      height: 40px;
+      border: 0;
+      pointer-events: none;
+      width: 2px;
+      background-color: orange;
+
+      &::before {
+        content: "";
+        display: block;
+        width: 0px;
+        height: 0px;
+        position: absolute;
+        top: -3px;
+        left: -4px;
+        background-color: transparent;
+        border-top: 5px solid orange;
+        border-left: 5px solid transparent;
+        border-right: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+      }
+    }
+  }
 }

--- a/src/editor/useEditor.ts
+++ b/src/editor/useEditor.ts
@@ -12,7 +12,9 @@ export default function useEditor(
   progressBarRef: React.RefObject<HTMLDivElement>,
   clipsBarRef: React.RefObject<HTMLDivElement>,
   bookmarksBarRef: React.RefObject<HTMLDivElement>,
-  initialVolume: number
+  initialVolume: number,
+  onBookmarkAdded: (b: number) => void,
+  initialBookmarks: number[] | undefined
 ) {
   const [playBtnIcon, setPlayBtnIcon] = useState<"play" | "pause">("play");
   const [volume, setVolume] = useState<number>(0.8);
@@ -148,6 +150,10 @@ export default function useEditor(
       progressBar.addEventListener("dblclick", () => {
         addClip();
       });
+    }
+
+    if (initialBookmarks && initialBookmarks.length > 0 && !bookmarksBar.classList.contains("noUi-target")) {
+      createBookmarksBar(initialBookmarks);
     }
   };
 
@@ -566,6 +572,7 @@ export default function useEditor(
     if (bookmarksBar.noUiSlider) bookmarksBar.noUiSlider.destroy();
 
     if (starts.length > 0) {
+      starts.sort((a, b) => a - b);
       noUiSlider.create(bookmarksBar, {
         start: starts,
         behaviour: "snap",
@@ -590,8 +597,8 @@ export default function useEditor(
       }
     }
     starts.push(currentProgress);
-    starts.sort((a, b) => a - b);
     createBookmarksBar(starts);
+    onBookmarkAdded(currentProgress);
   };
 
   const toggleShowTimeAsElapsed = () => {

--- a/src/editor/useEditor.ts
+++ b/src/editor/useEditor.ts
@@ -156,6 +156,11 @@ export default function useEditor(
     if (initialBookmarks && initialBookmarks.length > 0 && !bookmarksBar.classList.contains("noUi-target")) {
       createBookmarksBar(initialBookmarks);
     }
+
+    // When a bookmark is right clicked, remove.
+    // Pointer events are disabled everywhere except handles.
+    bookmarksBar.removeEventListener("mouseup", bookmarksBarMouseUp);
+    bookmarksBar.addEventListener("mouseup", bookmarksBarMouseUp);
   };
 
   /**
@@ -586,9 +591,6 @@ export default function useEditor(
       });
       // Disable dragging bookmarks
       bookmarksBar.noUiSlider!.disable();
-      // When a bookmark is right clicked, remove
-      bookmarksBar.removeEventListener("mouseup", bookmarksBarMouseUp);
-      bookmarksBar.addEventListener("mouseup", bookmarksBarMouseUp);
     }
   };
 

--- a/src/editor/useEditor.ts
+++ b/src/editor/useEditor.ts
@@ -574,6 +574,7 @@ export default function useEditor(
 
     if (starts.length > 0) {
       starts.sort((a, b) => a - b);
+      console.log("createBookmarksBar:", starts);
       noUiSlider.create(bookmarksBar, {
         start: starts,
         behaviour: "snap",
@@ -593,7 +594,7 @@ export default function useEditor(
 
   const bookmarksBarMouseUp = (ev: MouseEvent) => {
     if (ev.button === 2) {
-      console.log("clickckckckckc", ev);
+      console.log("bookmarksBarMouseUp", ev);
       const handle = ev.composedPath()[1] as HTMLDivElement;
       if (handle) {
         const handleN = handle.getAttribute("data-handle");
@@ -616,6 +617,10 @@ export default function useEditor(
       } else {
         starts = [Number(s)];
       }
+    }
+    if (starts.includes(currentProgress)) {
+      console.log("addBookmark: bookmark already exists at time:", currentProgress);
+      return;
     }
     starts.push(currentProgress);
     createBookmarksBar(starts);

--- a/src/libs/recorder/index.ts
+++ b/src/libs/recorder/index.ts
@@ -3,7 +3,7 @@ import ArgumentBuilder, { type CustomRegion, type Arguments } from "./argumentBu
 import RecordingsManager from "./recordingsManager";
 import Notifications from "./../helpers/notifications";
 import { store } from "@/app/store";
-import { isRecording } from "./recorderSlice";
+import { addBookmarkToRecording, isRecording } from "./recorderSlice";
 import { ipcRenderer } from "electron";
 import { logger } from "../logger";
 
@@ -15,6 +15,14 @@ ipcRenderer.on("startStopRecordingRegion-pressed", async () => {
   const b = await ipcRenderer.invoke("select-region-win");
   logger.info("Recorder", "Region selected", b);
   await Recorder.auto(b);
+});
+
+ipcRenderer.on("addBookmark-pressed", async () => {
+  if (!store.getState().recorder.isRecording) {
+    console.log("can't add bookmark when not recording");
+    return;
+  }
+  store.dispatch(addBookmarkToRecording());
 });
 
 export default class Recorder {

--- a/src/libs/recorder/recorderSlice.ts
+++ b/src/libs/recorder/recorderSlice.ts
@@ -7,13 +7,24 @@ interface RecordingState {
    * Recording time elapsed in seconds.
    */
   timeElapsed: number;
+
+  /**
+   * Bookmarks added whilst recording,
+   * added to final video object before adding
+   * to appropriate video json file on stop.
+   */
+  bookmarks: number[];
 }
 
 const recorderSlice = createSlice({
   name: "recorder",
-  initialState: { isRecording: false, timeElapsed: 0 } as RecordingState,
+  initialState: { isRecording: false, timeElapsed: 0, bookmarks: [] } as RecordingState,
   reducers: {
     isRecording(state, action: PayloadAction<boolean>) {
+      // Reset bookmarks when starting new recording.
+      if (action.payload) {
+        state.bookmarks = [];
+      }
       state.isRecording = action.payload;
     },
     /**
@@ -27,10 +38,16 @@ const recorderSlice = createSlice({
      */
     resetElapsed(state) {
       state.timeElapsed = 0;
+    },
+    /**
+     * Add bookmark to the currently recording video (at current `timeElapsed`).
+     */
+    addBookmarkToRecording(state) {
+      state.bookmarks.push(state.timeElapsed);
     }
   }
 });
 
-export const { isRecording, incrementElapsed, resetElapsed } = recorderSlice.actions;
+export const { isRecording, incrementElapsed, resetElapsed, addBookmarkToRecording } = recorderSlice.actions;
 
 export default recorderSlice.reducer;

--- a/src/libs/recorder/recordingsManager.ts
+++ b/src/libs/recorder/recordingsManager.ts
@@ -28,6 +28,7 @@ export default class RecordingsManager {
     recording.fileSize = fs.statSync(videoPath).size;
     recording.time = Date.now();
     recording.isClip = isClip;
+    recording.bookmarks = store.getState().recorder?.bookmarks;
 
     // Get video info from ffprobe
     ffprobe

--- a/src/settings/keybind/KeyBindings.tsx
+++ b/src/settings/keybind/KeyBindings.tsx
@@ -1,7 +1,7 @@
 import { type RootState } from "@/app/store";
 import { useDispatch, useSelector } from "react-redux";
 import NamedContainer from "../../common/NamedContainer";
-import { setStartStopRecording, setStartStopRecordingRegion } from "../settingsSlice";
+import { setAddBookmark, setStartStopRecording, setStartStopRecordingRegion } from "../settingsSlice";
 import KeyBindButton from "./KeyBindButton";
 
 export default function KeyBindings() {
@@ -25,6 +25,15 @@ export default function KeyBindings() {
           bind={state.startStopRecordingRegion}
           onUpdate={(newBind) => {
             dispatch(setStartStopRecordingRegion(newBind));
+          }}
+        />
+      </NamedContainer>
+      <NamedContainer title="Add Bookmark To Recording">
+        <KeyBindButton
+          name="addBookmark"
+          bind={state.addBookmark}
+          onUpdate={(newBind) => {
+            dispatch(setAddBookmark(newBind));
           }}
         />
       </NamedContainer>

--- a/src/settings/settingsSlice.ts
+++ b/src/settings/settingsSlice.ts
@@ -79,6 +79,9 @@ const settingsSlice = createSlice({
     },
     setStartStopRecordingRegion(state, action: PayloadAction<string>) {
       state.key.startStopRecordingRegion = action.payload;
+    },
+    setAddBookmark(state, action: PayloadAction<string>) {
+      state.key.addBookmark = action.payload;
     }
   }
 });
@@ -104,7 +107,8 @@ export const {
   setSeperateAudioTracks,
 
   setStartStopRecording,
-  setStartStopRecordingRegion
+  setStartStopRecordingRegion,
+  setAddBookmark
 } = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -57,6 +57,7 @@ export interface RecordingSettings {
 export interface KeyBindingSettings {
   startStopRecording: string;
   startStopRecordingRegion: string;
+  addBookmark: string;
 }
 
 export interface MonitorToRecord {

--- a/src/videos/types.ts
+++ b/src/videos/types.ts
@@ -12,4 +12,5 @@ export interface Video {
   fileSize?: number;
   fps?: string;
   duration?: number;
+  bookmarks?: number[];
 }

--- a/src/videos/videosSlice.ts
+++ b/src/videos/videosSlice.ts
@@ -36,11 +36,45 @@ const videosSlice = createSlice({
       } else {
         state.recordings = state.recordings.map(updt);
       }
+    },
+    videoBookmarkAdded: (state, action: PayloadAction<{ videoPath: string; isClip: boolean; bookmark: number }>) => {
+      const updt = (v: Video) => {
+        if (v.videoPath === action.payload.videoPath) {
+          if (v.bookmarks) {
+            v.bookmarks.push(action.payload.bookmark);
+          } else {
+            v.bookmarks = [action.payload.bookmark];
+          }
+        }
+        return v;
+      };
+
+      if (action.payload.isClip) {
+        state.clips = state.clips.map(updt);
+      } else {
+        state.recordings = state.recordings.map(updt);
+      }
+    },
+    videoBookmarkRemoved: (state, action: PayloadAction<{ videoPath: string; isClip: boolean; bookmark: number }>) => {
+      const updt = (v: Video) => {
+        if (v.videoPath === action.payload.videoPath) {
+          if (v.bookmarks) {
+            v.bookmarks.filter((b) => b !== action.payload.bookmark);
+          }
+        }
+        return v;
+      };
+
+      if (action.payload.isClip) {
+        state.clips = state.clips.map(updt);
+      } else {
+        state.recordings = state.recordings.map(updt);
+      }
     }
   }
 });
 
-export const { videoAdded, videoRemoved, videoRenamed } = videosSlice.actions;
+export const { videoAdded, videoRemoved, videoRenamed, videoBookmarkAdded, videoBookmarkRemoved } = videosSlice.actions;
 
 export const selectVideos = (state: VideosState, isClip: boolean) => (isClip ? state.clips : state.recordings);
 

--- a/src/videos/videosSlice.ts
+++ b/src/videos/videosSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { VideosState, Video } from "./types";
+import { removeFirst } from "@/libs/helpers/extensions/array";
 
 const videosSlice = createSlice({
   name: "videos",
@@ -59,7 +60,7 @@ const videosSlice = createSlice({
       const updt = (v: Video) => {
         if (v.videoPath === action.payload.videoPath) {
           if (v.bookmarks) {
-            v.bookmarks.filter((b) => b !== action.payload.bookmark);
+            v.bookmarks = removeFirst(v.bookmarks, action.payload.bookmark);
           }
         }
         return v;


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->
Added support for video bookmarks. You can add these to your timeline with the button or keybind (B), or add one whilst recording by pressing F2 (default).

![image](https://github.com/sbondCo/Casterr/assets/37304121/cf83cdec-57be-4cfc-9aaa-c4b98e7d3524)


If you are like me and prefer to record your whole gameplay and come back later to edit out your highlights or funny moments, this will come in handy, saving you time skimming through the whole video to find what you want to save. Simply press F2 (default bind) to bookmark a moment for clipping later in the editor.


Closes #394 