### PR TITLE
createThumbnail: exit if output file already exists

### DIFF
--- a/src/libs/recorder/recordingsManager.ts
+++ b/src/libs/recorder/recordingsManager.ts
@@ -19,6 +19,8 @@ export default class RecordingsManager {
     // Throw exception if video from videoPath does not exist
     if (!fs.existsSync(videoPath)) throw new Error("Can't add recording that doesn't exist!");
 
+    console.log("adding video", videoPath);
+
     const ffprobe = new FFmpeg("ffprobe");
     const recording = {} as Video;
 
@@ -98,7 +100,7 @@ export default class RecordingsManager {
       path.basename(videoPath) + ".png"
     );
 
-    await ffmpeg.run(`-i "${videoPath}" -frames:v 1 "${thumbPath}"`);
+    await ffmpeg.run(`-n -i "${videoPath}" -frames:v 1 "${thumbPath}"`);
 
     return thumbPath;
   }

--- a/src/videos/Videos.tsx
+++ b/src/videos/Videos.tsx
@@ -15,6 +15,7 @@ import VideosGrid from "./VideosGrid";
 export default function Videos() {
   const pageRef = useRef<HTMLDivElement>(null);
   const { dropZoneShown, dropZoneFLen } = useDragAndDrop(pageRef, (f: File) => {
+    console.log(f, f.type.includes("video"));
     if (f.type.includes("video")) {
       // TODO when on `clips` sub page, add dropped videos as clips
       RecordingsManager.add(f.path).catch((e) => {


### PR DESCRIPTION
instead of hanging on 'overwrite?' output, which can result in a video not being added

<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->
When creating a thumbnail, we could get hung on ffmpeg asking us if we want to overwrite an existing file. Added `-n` option so we don't overwrite and exit immediately in this case.

In the flow of dropping a video to import it, this could cause us to stay hung waiting on ffmpeg to exit, which would result in our video not being imported.
