### PR TITLE
Experimental: Linux hardware encoding (NVENC)

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -35,7 +35,8 @@ export const DEFAULT_SETTINGS = {
     zeroLatency: true,
     ultraFast: true,
     audioDevicesToRecord: [] as string[],
-    seperateAudioTracks: false
+    seperateAudioTracks: false,
+    hardwareEncoding: false
   },
   key: {
     startStopRecording: "F9",

--- a/src/common/NamedContainer.tsx
+++ b/src/common/NamedContainer.tsx
@@ -2,16 +2,20 @@ import type { CommonComponentProps } from "./types";
 
 type NamedContainerProps = {
   title: string;
+  desc?: string;
   children: React.ReactNode;
   row?: boolean;
 } & CommonComponentProps;
 
-export default function NamedContainer({ title, children, row, className }: NamedContainerProps) {
+export default function NamedContainer({ title, desc, children, row, className }: NamedContainerProps) {
   const containerClass = row ? "flex flex-row-reverse justify-end" : "";
 
   return (
     <div className={`pb-5 last:pb-0 ${containerClass} ${className ?? ""}`}>
-      <p className={`mb-1.5 mr-2.5 font-bold capitalize ${row ? "ml-2.5" : ""}`}>{title}</p>
+      <div className={`mb-1.5 mr-2.5 ${row ? "ml-2.5" : ""}`}>
+        <p className="font-bold capitalize">{title}</p>
+        {desc && <p className="text-sm">{desc}</p>}
+      </div>
       {children}
     </div>
   );

--- a/src/libs/recorder/argumentBuilder.ts
+++ b/src/libs/recorder/argumentBuilder.ts
@@ -64,6 +64,10 @@ export default class ArgumentBuilder {
     // Audio maps
     args.push(`${ArgumentBuilder.audioMaps}`);
 
+    if (ArgumentBuilder.rs.hardwareEncoding) {
+      args.push(`-c:v h264_nvenc -profile high444p -pixel_format yuv444p -preset lossless`);
+    }
+
     // Video output path
     const videoOutputPath = await ArgumentBuilder.videoOutputPath();
     args.push(`"${videoOutputPath}"`);

--- a/src/settings/pages/Recording.tsx
+++ b/src/settings/pages/Recording.tsx
@@ -93,9 +93,15 @@ export default function Recording() {
         />
       </NamedContainer>
 
-      <NamedContainer title="Hardware Encoding" row>
-        <TickBox ticked={state.hardwareEncoding} onChange={(t) => dispatch(setHardwareEncoding(t))} />
-      </NamedContainer>
+      {process.platform === "linux" && (
+        <NamedContainer
+          title="Hardware Encoding"
+          desc="Experimental NVENC Support. Offloads Video Encoding to NVIDIA GPU."
+          row
+        >
+          <TickBox ticked={state.hardwareEncoding} onChange={(t) => dispatch(setHardwareEncoding(t))} />
+        </NamedContainer>
+      )}
 
       <NamedContainer title="Separate Audio Tracks" row>
         <TickBox ticked={state.seperateAudioTracks} onChange={(t) => dispatch(setSeperateAudioTracks(t))} />

--- a/src/settings/pages/Recording.tsx
+++ b/src/settings/pages/Recording.tsx
@@ -12,6 +12,7 @@ import NamedContainer from "../../common/NamedContainer";
 import {
   setFormat,
   setFps,
+  setHardwareEncoding,
   setMonitorToRecord,
   setResolution,
   setSeperateAudioTracks,
@@ -90,6 +91,10 @@ export default function Recording() {
           items={APP_SETTINGS.supportedRecordingFormats}
           onChange={(s) => dispatch(setFormat(s as string))}
         />
+      </NamedContainer>
+
+      <NamedContainer title="Hardware Encoding" row>
+        <TickBox ticked={state.hardwareEncoding} onChange={(t) => dispatch(setHardwareEncoding(t))} />
       </NamedContainer>
 
       <NamedContainer title="Separate Audio Tracks" row>

--- a/src/settings/settingsSlice.ts
+++ b/src/settings/settingsSlice.ts
@@ -70,6 +70,9 @@ const settingsSlice = createSlice({
     setSeperateAudioTracks(state, action: PayloadAction<boolean>) {
       state.recording.seperateAudioTracks = action.payload;
     },
+    setHardwareEncoding(state, action: PayloadAction<boolean>) {
+      state.recording.hardwareEncoding = action.payload;
+    },
 
     //
     // Key Binding Settings
@@ -105,6 +108,7 @@ export const {
   setUltraFast,
   toggleAudioDeviceToRecord,
   setSeperateAudioTracks,
+  setHardwareEncoding,
 
   setStartStopRecording,
   setStartStopRecordingRegion,

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -52,6 +52,11 @@ export interface RecordingSettings {
    * different audio tracks.
    */
   seperateAudioTracks: boolean;
+
+  /**
+   * If we should offload encoding to GPU.
+   */
+  hardwareEncoding: boolean;
 }
 
 export interface KeyBindingSettings {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->

New experimental setting to enable NVENC support to offload video encoding to GPU so FPS in games are not effected (toggleable in recording settings).

Only support for NVENC currently, will see If I can test and support hardware encoding on AMD cards.

