### PR TITLE
Fix AudioDevicesToRecord on Linux

### DIFF
--- a/entry/serve.ts
+++ b/entry/serve.ts
@@ -79,6 +79,7 @@ async function openElectron() {
         // If was able to get main.tsx, then vite has
         // launched the react app, so we can now open Electron
         if (resp.statusCode === 200) {
+          log(`Starting Casterr..`);
           resolve(exec(`${CROSSENV_PATH} NODE_ENV=dev SERVER_URL=${viteBase} ${ELECTRON_PATH} .`));
         } else {
           log(`Recieved HTTP code ${resp.statusCode ?? "UNDEFINED"} from vite!`);

--- a/src/libs/recorder/argumentBuilder.ts
+++ b/src/libs/recorder/argumentBuilder.ts
@@ -247,6 +247,7 @@ export default class ArgumentBuilder {
           break;
       }
     }
+    // https://trac.ffmpeg.org/wiki/Scaling
     return `-vf scale=${res.width}:${ArgumentBuilder.rs.resolutionKeepAspectRatio ? "-1" : res.height}`;
   }
 

--- a/src/libs/recorder/deviceManager.ts
+++ b/src/libs/recorder/deviceManager.ts
@@ -21,15 +21,13 @@ export interface Devices {
 export interface AudioDevice {
   /**
    * Source number
-   *  - On  **Linux** used to store source number of audio device and as key for ListBox
+   *  - On  **Linux** used to store name of audio device and as key for ListBox
    *  - On **Windows** used only as a key for ListBox (currently set as the name as device name)
    */
   id: number | string;
 
   /**
    * Name of device.
-   * Usually the same as ID, but in certain cases will
-   * contain a more reader friendly version of the devices name.
    */
   name: string;
 

--- a/src/libs/recorder/deviceManager.ts
+++ b/src/libs/recorder/deviceManager.ts
@@ -67,7 +67,7 @@ export default class DeviceManager {
           stdoutCallback: (out: string) => {
             // If current device is an input device (eg. microphone)
             let isInputDevice = false;
-            let sourceNumber = 0;
+            let sourceName = "";
 
             // Find audioDevices and add them to audioDevices array
             out
@@ -76,9 +76,9 @@ export default class DeviceManager {
               .forEach((l: string) => {
                 const ll = l.toLowerCase();
 
-                // Get source number
-                if (ll.includes("source")) {
-                  sourceNumber = parseInt(ll.replace("source #", ""), 10);
+                // Hopefully this is unique. Looks like it is.
+                if (ll.includes("	name: ")) {
+                  sourceName = ll.replace("	name: ", "");
                 }
 
                 if (ll.includes("name: alsa_input")) isInputDevice = true;
@@ -87,7 +87,7 @@ export default class DeviceManager {
                 if (ll.includes("alsa.card_name")) {
                   // Add input devices to audioDevices array
                   audioDevices.push({
-                    id: sourceNumber,
+                    id: sourceName,
                     name: l.replace("alsa.card_name = ", "").replaceAll('"', "").replaceAll("\t", ""),
                     isInput: isInputDevice
                   });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./app/App";
 import "./index.css";
 import "@/common/common.scss";
 import { registerAllBinds } from "./settings/keybind/keyBinds";
+import checkSettings from "./settings/ensure";
 
 const container = document.getElementById("root");
 const root = createRoot(container!);
@@ -15,4 +16,7 @@ root.render(
   </React.StrictMode>
 );
 
+checkSettings().catch((err) => {
+  console.error("checkSettings failed!", err);
+});
 registerAllBinds();

--- a/src/settings/ensure.ts
+++ b/src/settings/ensure.ts
@@ -2,7 +2,7 @@ import { store } from "@/app/store";
 import DeviceManager from "@/libs/recorder/deviceManager";
 import { logger } from "@/libs/logger";
 import Notifications from "@/libs/helpers/notifications";
-import { removeAudioDevicesToRecord, toggleAudioDeviceToRecord } from "./settingsSlice";
+import { removeAudioDevicesToRecord } from "./settingsSlice";
 
 /**
  * Check settings state to ensure they are correct.

--- a/src/settings/ensure.ts
+++ b/src/settings/ensure.ts
@@ -1,0 +1,58 @@
+import { store } from "@/app/store";
+import DeviceManager from "@/libs/recorder/deviceManager";
+import { logger } from "@/libs/logger";
+import Notifications from "@/libs/helpers/notifications";
+import { removeAudioDevicesToRecord, toggleAudioDeviceToRecord } from "./settingsSlice";
+
+/**
+ * Check settings state to ensure they are correct.
+ */
+export default async function checkSettings() {
+  try {
+    const s = store.getState().settings;
+    await checkAudioDevicesToRecord(s?.recording?.audioDevicesToRecord);
+  } catch (err) {
+    logger.error("settings/ensure", "checkSettings failed!", err);
+  }
+}
+
+/**
+ * Ensure configures audio devices to record are
+ * available to us, if not remove and show popup
+ * to alert user their audio device was removed.
+ */
+async function checkAudioDevicesToRecord(s: string[]) {
+  const dRm: string[] = [];
+  try {
+    if (s?.length < 0) {
+      logger.debug("settings/ensure", "checkAudioDevicesToRecord recieved to no devices.. skipping check.");
+      return;
+    }
+    const devs = await DeviceManager.getDevices();
+    if (devs?.audio?.length < 0) {
+      logger.info("settings/ensure", "checkAudioDevicesToRecord found no audio devices.");
+      return;
+    }
+    for (let i = 0; i < s.length; i++) {
+      const adtr = s[i];
+      if (!devs.audio.find((d) => d.id === adtr)) {
+        logger.info("settings/ensure", "checkAudioDevicesToRecord found non existant audio device:", adtr);
+        dRm.push(adtr);
+      } else {
+        logger.info("settings/ensure", "checkAudioDevicesToRecord audio device exists:", adtr);
+      }
+    }
+  } catch (err) {
+    logger.error("settings/ensure", "checkAudioDevicesToRecord failed!", err);
+  }
+  if (dRm.length > 0) {
+    store.dispatch(removeAudioDevicesToRecord(dRm));
+    await Notifications.popup({
+      id: "SETTINGS-ENSURE-ADTR",
+      title: "Removed Unrecognized Audio Devices",
+      message:
+        "One or more audio devices to record were no longer recognized. Please re-configure this option in settings.",
+      showCancel: true
+    });
+  }
+}

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./Settings";
 
 export * from "../common/NamedContainer";
+export * from "./ensure";

--- a/src/settings/settingsSlice.ts
+++ b/src/settings/settingsSlice.ts
@@ -74,6 +74,11 @@ const settingsSlice = createSlice({
         );
       }
     },
+    removeAudioDevicesToRecord(state, action: PayloadAction<string[]>) {
+      state.recording.audioDevicesToRecord = state.recording.audioDevicesToRecord.filter(
+        (id) => !action.payload.includes(id)
+      );
+    },
     setSeperateAudioTracks(state, action: PayloadAction<boolean>) {
       state.recording.seperateAudioTracks = action.payload;
     },
@@ -116,6 +121,7 @@ export const {
   setZeroLatency,
   setUltraFast,
   toggleAudioDeviceToRecord,
+  removeAudioDevicesToRecord,
   setSeperateAudioTracks,
   setHardwareEncoding,
 


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->
- Use device name instead of current source number for saving device in audioDevicesToRecord setting.
- Create new check to ensure the audioDevicesToRecord are recognized. If not, remove them from the settings aray and show a popup.

Closes #486 
