### PR TITLE
Saved Region To Record setting

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -49,6 +49,7 @@ export const DEFAULT_SETTINGS = {
   key: {
     startStopRecording: "F9",
     startStopRecordingRegion: "F10",
+    startStopRecordingSavedRegion: "Shift+F10",
     addBookmark: "F2"
   }
 } as Settings;

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -43,7 +43,8 @@ export const DEFAULT_SETTINGS = {
     ultraFast: true,
     audioDevicesToRecord: [] as string[],
     seperateAudioTracks: false,
-    hardwareEncoding: false
+    hardwareEncoding: false,
+    regionToRecord: { x: 0, y: 0, width: 0, height: 0 }
   },
   key: {
     startStopRecording: "F9",

--- a/src/common/Icon.tsx
+++ b/src/common/Icon.tsx
@@ -40,7 +40,8 @@ export type Icons =
   | "bookmark"
   | "film"
   | "camera"
-  | "trash";
+  | "trash"
+  | "move";
 
 export type IconDirection = "up" | "down" | "left" | "right";
 
@@ -458,6 +459,20 @@ function getIcon(name: Icons): { viewBox: string; el: JSX.Element } {
               fill="currentColor"
             />
           </>
+        )
+      };
+    case "move":
+      return {
+        viewBox: "0 0 512 512",
+        el: (
+          <path
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="32"
+            d="M176 112l80-80 80 80M255.98 32l.02 448M176 400l80 80 80-80M400 176l80 80-80 80M112 176l-80 80 80 80M32 256h448"
+          />
         )
       };
     default:

--- a/src/common/RegionSelect.tsx
+++ b/src/common/RegionSelect.tsx
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron";
 import { useEffect, useRef } from "react";
+import { type CustomRegion } from "@/libs/recorder/argumentBuilder";
 
 export default function RegionSelect() {
   const dRef = useRef<HTMLDivElement>(null);
@@ -97,7 +98,7 @@ export default function RegionSelect() {
       console.log("stopDraw");
       isDrawing = false;
       const br = regionDiv.getBoundingClientRect();
-      ipcRenderer.send("region-selected", { x: br.x, y: br.y, width: br.width, height: br.height });
+      ipcRenderer.send("region-selected", { x: br.x, y: br.y, width: br.width, height: br.height } as CustomRegion);
     } catch (err) {
       ipcRenderer.send("region-select-cancelled", "stopDraw failed", err);
     }

--- a/src/common/TextBox.tsx
+++ b/src/common/TextBox.tsx
@@ -1,7 +1,7 @@
 import useDebouncer from "@/hooks/useDebouncer";
 import { logger } from "@/libs/logger";
 import { ipcRenderer } from "electron";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Icon, { type Icons } from "./Icon";
 import { type CommonComponentProps } from "./types";
 
@@ -40,6 +40,10 @@ export default function TextBox(props: TextBoxProps) {
 
   const { doDebounce } = useDebouncer(debounce);
   const [curVal, setCurVal] = useState(value);
+
+  useEffect(() => {
+    setCurVal(value);
+  }, [value]);
 
   // newVal param set as string becuase we get input value
   // from onBlur event (e.target.value), which returns as only string.

--- a/src/libs/recorder/index.ts
+++ b/src/libs/recorder/index.ts
@@ -25,7 +25,8 @@ ipcRenderer.on("startStopRecordingSavedRegion-pressed", async () => {
     Notifications.popup({
       id: "CANT-RECORD-SR",
       title: "Can't Record Saved Region!",
-      message: "A width and or height has not been provided in settings!"
+      message: "A width and or height has not been provided in settings!",
+      showCancel: true
     }).catch((err) => logger.error("Recorder", "Failed to show CANT-RECORD-SR popup", err));
     return;
   }

--- a/src/libs/recorder/index.ts
+++ b/src/libs/recorder/index.ts
@@ -17,6 +17,22 @@ ipcRenderer.on("startStopRecordingRegion-pressed", async () => {
   await Recorder.auto(b);
 });
 
+ipcRenderer.on("startStopRecordingSavedRegion-pressed", async () => {
+  const r = store.getState().settings.recording.regionToRecord;
+  // A width and height at the very least is required.
+  if (!r.width || !r.height) {
+    logger.error("Recorder", "Cant record saved region", "a width and height must be set");
+    Notifications.popup({
+      id: "CANT-RECORD-SR",
+      title: "Can't Record Saved Region!",
+      message: "A width and or height has not been provided in settings!"
+    }).catch((err) => logger.error("Recorder", "Failed to show CANT-RECORD-SR popup", err));
+    return;
+  }
+  logger.info("Recorder", "Saved Region", r);
+  await Recorder.auto(r);
+});
+
 ipcRenderer.on("addBookmark-pressed", async () => {
   if (store.getState().recorder.recordingStatus !== 1) {
     console.log("can't add bookmark when not recording");

--- a/src/settings/keybind/KeyBindings.tsx
+++ b/src/settings/keybind/KeyBindings.tsx
@@ -1,7 +1,12 @@
 import { type RootState } from "@/app/store";
 import { useDispatch, useSelector } from "react-redux";
 import NamedContainer from "../../common/NamedContainer";
-import { setAddBookmark, setStartStopRecording, setStartStopRecordingRegion } from "../settingsSlice";
+import {
+  setAddBookmark,
+  setStartStopRecording,
+  setStartStopRecordingRegion,
+  setStartStopRecordingSavedRegion
+} from "../settingsSlice";
 import KeyBindButton from "./KeyBindButton";
 
 export default function KeyBindings() {
@@ -19,12 +24,21 @@ export default function KeyBindings() {
           }}
         />
       </NamedContainer>
-      <NamedContainer title="Start/Stop Recording A Region">
+      <NamedContainer title="Record A Region">
         <KeyBindButton
           name="startStopRecordingRegion"
           bind={state.startStopRecordingRegion}
           onUpdate={(newBind) => {
             dispatch(setStartStopRecordingRegion(newBind));
+          }}
+        />
+      </NamedContainer>
+      <NamedContainer title="Record Saved Region">
+        <KeyBindButton
+          name="startStopRecordingSavedRegion"
+          bind={state.startStopRecordingSavedRegion}
+          onUpdate={(newBind) => {
+            dispatch(setStartStopRecordingSavedRegion(newBind));
           }}
         />
       </NamedContainer>

--- a/src/settings/pages/Recording.tsx
+++ b/src/settings/pages/Recording.tsx
@@ -14,6 +14,7 @@ import {
   setFps,
   setHardwareEncoding,
   setMonitorToRecord,
+  setRegionToRecord,
   setResolution,
   setResolutionCustom,
   setResolutionKeepAspectRatio,
@@ -25,6 +26,9 @@ import {
   toggleAudioDeviceToRecord
 } from "../settingsSlice";
 import type { ResolutionScale } from "../types";
+import Button from "@/common/Button";
+import Tooltip from "@/common/Tooltip";
+import { ipcRenderer } from "electron";
 
 export default function Recording() {
   const state = useSelector((store: RootState) => store.settings.recording);
@@ -51,6 +55,15 @@ export default function Recording() {
       .catch((err) => logger.error("Recording", "Failed to get audio devices!", err));
   }, []);
 
+  async function dragRegionToRecord() {
+    try {
+      const b = await ipcRenderer.invoke("select-region-win");
+      dispatch(setRegionToRecord({ x: b.x, y: b.y, width: b.width, height: b.height }));
+    } catch (err) {
+      logger.error("Settings/Recording", "Failed to drag new region", err);
+    }
+  }
+
   return (
     <>
       <NamedContainer title="Video Device">
@@ -67,6 +80,50 @@ export default function Recording() {
           items={monitors}
           onChange={(s) => dispatch(setMonitorToRecord(s as DropDownItem))}
         />
+      </NamedContainer>
+
+      <NamedContainer title="Region To Record" desc="Save a custom region so you don't always have to drag one.">
+        <div className="flex row gap-3 items-center">
+          <b>X</b>
+          <TextBox
+            type="number"
+            value={state.regionToRecord.x}
+            placeholder={0}
+            onChange={(s) => {
+              dispatch(setRegionToRecord({ x: s }));
+            }}
+          />
+          <b>Y</b>
+          <TextBox
+            type="number"
+            value={state.regionToRecord?.y ?? ""}
+            placeholder={0}
+            onChange={(s) => {
+              dispatch(setRegionToRecord({ y: s }));
+            }}
+          />
+          <b>W</b>
+          <TextBox
+            type="number"
+            value={state.regionToRecord?.width ?? ""}
+            placeholder={0}
+            onChange={(s) => {
+              dispatch(setRegionToRecord({ width: s }));
+            }}
+          />
+          <b>H</b>
+          <TextBox
+            type="number"
+            value={state.regionToRecord?.height ?? ""}
+            placeholder={0}
+            onChange={(s) => {
+              dispatch(setRegionToRecord({ height: s }));
+            }}
+          />
+          <Tooltip text="Drag Region">
+            <Button icon="move" onClick={dragRegionToRecord} />
+          </Tooltip>
+        </div>
       </NamedContainer>
 
       <NamedContainer title="Format">

--- a/src/settings/settingsSlice.ts
+++ b/src/settings/settingsSlice.ts
@@ -86,10 +86,10 @@ const settingsSlice = createSlice({
       state.recording.hardwareEncoding = action.payload;
     },
     setRegionToRecord(state, action: PayloadAction<{ x?: number; y?: number; width?: number; height?: number }>) {
-      if (action.payload.x) state.recording.regionToRecord.x = action.payload.x;
-      if (action.payload.y) state.recording.regionToRecord.y = action.payload.y;
-      if (action.payload.width) state.recording.regionToRecord.width = action.payload.width;
-      if (action.payload.height) state.recording.regionToRecord.height = action.payload.height;
+      if (typeof action.payload.x === "number") state.recording.regionToRecord.x = action.payload.x;
+      if (typeof action.payload.y === "number") state.recording.regionToRecord.y = action.payload.y;
+      if (typeof action.payload.width === "number") state.recording.regionToRecord.width = action.payload.width;
+      if (typeof action.payload.height === "number") state.recording.regionToRecord.height = action.payload.height;
     },
 
     //

--- a/src/settings/settingsSlice.ts
+++ b/src/settings/settingsSlice.ts
@@ -101,6 +101,9 @@ const settingsSlice = createSlice({
     setStartStopRecordingRegion(state, action: PayloadAction<string>) {
       state.key.startStopRecordingRegion = action.payload;
     },
+    setStartStopRecordingSavedRegion(state, action: PayloadAction<string>) {
+      state.key.startStopRecordingSavedRegion = action.payload;
+    },
     setAddBookmark(state, action: PayloadAction<string>) {
       state.key.addBookmark = action.payload;
     }
@@ -134,6 +137,7 @@ export const {
 
   setStartStopRecording,
   setStartStopRecordingRegion,
+  setStartStopRecordingSavedRegion,
   setAddBookmark
 } = settingsSlice.actions;
 

--- a/src/settings/settingsSlice.ts
+++ b/src/settings/settingsSlice.ts
@@ -85,6 +85,12 @@ const settingsSlice = createSlice({
     setHardwareEncoding(state, action: PayloadAction<boolean>) {
       state.recording.hardwareEncoding = action.payload;
     },
+    setRegionToRecord(state, action: PayloadAction<{ x?: number; y?: number; width?: number; height?: number }>) {
+      if (action.payload.x) state.recording.regionToRecord.x = action.payload.x;
+      if (action.payload.y) state.recording.regionToRecord.y = action.payload.y;
+      if (action.payload.width) state.recording.regionToRecord.width = action.payload.width;
+      if (action.payload.height) state.recording.regionToRecord.height = action.payload.height;
+    },
 
     //
     // Key Binding Settings
@@ -124,6 +130,7 @@ export const {
   removeAudioDevicesToRecord,
   setSeperateAudioTracks,
   setHardwareEncoding,
+  setRegionToRecord,
 
   setStartStopRecording,
   setStartStopRecordingRegion,

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -81,6 +81,10 @@ export interface RecordingSettings {
 export interface KeyBindingSettings {
   startStopRecording: string;
   startStopRecordingRegion: string;
+  /**
+   * Start/stop recording the `regionToRecord` setting if set.
+   */
+  startStopRecordingSavedRegion: string;
   addBookmark: string;
 }
 

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -69,6 +69,13 @@ export interface RecordingSettings {
    * If we should offload encoding to GPU.
    */
   hardwareEncoding: boolean;
+
+  /**
+   * Saved custom region of screen to record.
+   * If a user only records a certain space of
+   * their screen always, this will help by saving that region.
+   */
+  regionToRecord: { x: number; y: number; width: number; height: number };
 }
 
 export interface KeyBindingSettings {


### PR DESCRIPTION
<!-- Make sure your code is formatted by running `npm run prettier:formatall`. -->

### Changes made
<!-- Describe changes made here. Use screenshots if changes are visual! -->
Create a region to record setting for saving a custom region to quickly record, along with new keybind for using saved region (Shift+F10 by default) instead of dragging a new one.

Closes #487 